### PR TITLE
Fix library name (xtst).

### DIFF
--- a/x11/build.rs
+++ b/x11/build.rs
@@ -14,5 +14,5 @@ fn main () {
   if cfg!(feature="xmu") { let _ = pkg_config::find_library("xmu"); }
   if cfg!(feature="xrender") { let _ = pkg_config::find_library("xrender"); }
   if cfg!(feature="xt") { let _ = pkg_config::find_library("xt"); }
-  if cfg!(feature="xtest") { let _ = pkg_config::find_library("xtest"); }
+  if cfg!(feature="xtest") { let _ = pkg_config::find_library("xtst"); }
 }


### PR DESCRIPTION
Fix library name for X Record Extension to `xtst` in build.rs