### PR TITLE
Add XInput2 bindings and example app

### DIFF
--- a/examples/input/.gitignore
+++ b/examples/input/.gitignore
@@ -1,0 +1,2 @@
+Cargo.lock
+target

--- a/examples/input/Cargo.toml
+++ b/examples/input/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "x11-input"
+version = "0.0.0"
+
+[dependencies]
+libc = "*"
+
+[dependencies.x11]
+path = "../../x11"
+features = ["xlib", "xinput"]
+
+[[bin]]
+name = "x11-xinput"
+path = "main.rs"

--- a/examples/input/demo_window.rs
+++ b/examples/input/demo_window.rs
@@ -1,0 +1,118 @@
+extern crate x11;
+extern crate libc;
+
+use std::ffi::CString;
+use std::ptr::{
+  null,
+  null_mut,
+};
+use std::mem::{zeroed};
+use libc::{c_uint};
+use x11::{xlib};
+
+/// Provides a basic framework for connecting to an X Display,
+/// creating a window, displaying it and running the event loop
+pub struct DemoWindow {
+    pub display: *mut xlib::Display,
+    pub window: xlib::Window,
+
+    wm_protocols: xlib::Atom,
+    wm_delete_window: xlib::Atom
+}
+
+impl DemoWindow {
+    /// Create a new window with a given title and size
+    pub fn new(title: &str, width: u32, height: u32) -> DemoWindow {
+        unsafe {
+            // Open display
+            let display = xlib::XOpenDisplay(null());
+            if display == null_mut() {
+                panic!("can't open display");
+            }
+
+            // Load atoms
+            let wm_delete_window_str = CString::new("WM_DELETE_WINDOW").unwrap();
+            let wm_protocols_str = CString::new("WM_PROTOCOLS").unwrap();
+
+            let wm_delete_window = xlib::XInternAtom(display, wm_delete_window_str.as_ptr(), xlib::False);
+            let wm_protocols = xlib::XInternAtom(display, wm_protocols_str.as_ptr(), xlib::False);
+
+            if wm_delete_window == 0 || wm_protocols == 0 {
+                panic!("can't load atoms");
+            }
+
+            // Create window
+            let screen_num = xlib::XDefaultScreen(display);
+            let root = xlib::XRootWindow(display, screen_num);
+            let white_pixel = xlib::XWhitePixel(display, screen_num);
+
+            let mut attributes: xlib::XSetWindowAttributes = zeroed();
+            attributes.background_pixel = white_pixel;
+
+            let window = xlib::XCreateWindow(display, root, 0, 0, width as c_uint, height as c_uint, 0, 0,
+                                             xlib::InputOutput as c_uint, null_mut(),
+                                             xlib::CWBackPixel, &mut attributes);
+            // Set window title
+            let title_str = CString::new(title).unwrap();
+            xlib::XStoreName(display, window, title_str.as_ptr() as *mut _);
+
+            // Subscribe to delete (close) events
+            let mut protocols = [wm_delete_window];
+
+            if xlib::XSetWMProtocols(display, window, &mut protocols[0] as *mut xlib::Atom, 1) == xlib::False {
+                panic!("can't set WM protocols");
+            }
+
+            DemoWindow{
+                display: display,
+                window: window,
+                wm_protocols: wm_protocols,
+                wm_delete_window: wm_delete_window
+            }
+        }
+    }
+
+    /// Display the window
+    pub fn show(&mut self) {
+        unsafe {
+            xlib::XMapWindow(self.display, self.window);
+        }
+    }
+
+    /// Process events for the window. Window close events are handled automatically,
+    /// other events are passed on to |event_handler|
+    pub fn run_event_loop<EventHandler>(&mut self, mut event_handler: EventHandler)
+        where EventHandler: FnMut(&xlib::XEvent) {
+            let mut event: xlib::XEvent = unsafe{zeroed()};
+            loop {
+                unsafe{xlib::XNextEvent(self.display, &mut event)};
+                match event.get_type() {
+                    xlib::ClientMessage => {
+                        let xclient: xlib::XClientMessageEvent = From::from(event);
+
+                        // WM_PROTOCOLS client message
+                        if xclient.message_type == self.wm_protocols && xclient.format == 32 {
+                            let protocol = xclient.data.get_long(0) as xlib::Atom;
+
+                            // WM_DELETE_WINDOW (close event)
+                            if protocol == self.wm_delete_window {
+                                break;
+                            }
+                        }
+                    },
+                    _ => event_handler(&event)
+                }
+            }
+        }
+}
+
+impl Drop for DemoWindow {
+    /// Destroys the window and disconnects from the display
+    fn drop(&mut self) {
+        unsafe {
+            xlib::XDestroyWindow(self.display, self.window);
+            xlib::XCloseDisplay(self.display);
+        }
+    }
+}
+

--- a/examples/input/main.rs
+++ b/examples/input/main.rs
@@ -1,0 +1,268 @@
+// XInput2 example for x11-rs
+//
+// This is a basic example showing how to use XInput2 to read
+// keyboard, mouse and other input events in X11.
+//
+// See Pete Hutterer's "XI2 Recipes" blog series,
+// starting at http://who-t.blogspot.co.uk/2009/05/xi2-recipes-part-1.html
+// for a guide.
+
+extern crate x11;
+extern crate libc;
+
+use std::ffi::{CString};
+use std::mem::{transmute};
+use std::slice::from_raw_parts;
+use x11::{xlib, xinput2};
+use libc::{c_uchar, c_int, c_uint};
+
+mod demo_window;
+use demo_window::DemoWindow;
+
+const TITLE: &'static str = "XInput Demo";
+const DEFAULT_WIDTH: c_uint = 640;
+const DEFAULT_HEIGHT: c_uint = 480;
+
+#[derive(Debug)]
+enum AxisType {
+    HorizontalScroll,
+    VerticalScroll,
+    Other
+}
+
+#[derive(Debug)]
+struct Axis {
+    id: i32,
+    device_id: i32,
+    axis_number: i32,
+    axis_type: AxisType
+}
+
+#[derive(Debug)]
+struct AxisValue {
+    device_id: i32,
+    axis_number: i32,
+    value: f64
+}
+
+struct InputState {
+    cursor_pos: (f64, f64),
+    axis_values: Vec<AxisValue>
+}
+
+fn read_input_axis_info(display: *mut xlib::Display) -> Vec<Axis> {
+    let mut axis_list = Vec::new();
+    let mut device_count = 0;
+
+    // only get events from the master devices which are 'attached'
+    // to the keyboard or cursor
+    let devices = unsafe{xinput2::XIQueryDevice(display, xinput2::XIAllMasterDevices, &mut device_count)};
+    for i in 0..device_count {
+        let device = unsafe { *(devices.offset(i as isize)) };
+        for k in 0..device.num_classes {
+            let class = unsafe { *(device.classes.offset(k as isize)) };
+            match unsafe { (*class)._type } {
+                xinput2::XIScrollClass => {
+                    let scroll_class: &xinput2::XIScrollClassInfo = unsafe{transmute(class)};
+                    axis_list.push(Axis{
+                        id: scroll_class.sourceid,
+                        device_id: device.deviceid,
+                        axis_number: scroll_class.number,
+                        axis_type: match scroll_class.scroll_type {
+                            xinput2::XIScrollTypeHorizontal => AxisType::HorizontalScroll,
+                            xinput2::XIScrollTypeVertical => AxisType::VerticalScroll,
+                            _ => { unreachable!() }
+                        }
+                    })
+                },
+                xinput2::XIValuatorClass => {
+                    let valuator_class: &xinput2::XIValuatorClassInfo = unsafe{transmute(class)};
+                    axis_list.push(Axis{
+                        id: valuator_class.sourceid,
+                        device_id: device.deviceid,
+                        axis_number: valuator_class.number,
+                        axis_type: AxisType::Other
+                    })
+                },
+                _ => { /* TODO */ }
+            }
+        }
+    }
+
+    axis_list.sort_by(|a, b| {
+        if a.device_id != b.device_id {
+            a.device_id.cmp(&b.device_id)
+        } else if a.id != b.id {
+            a.id.cmp(&b.id)
+        } else {
+            a.axis_number.cmp(&b.axis_number)
+        }
+    });
+    axis_list
+}
+
+/// Given an input motion event for an axis and the previous
+/// state of the axises, return the horizontal/vertical
+/// scroll deltas
+fn calc_scroll_deltas(event: &xinput2::XIDeviceEvent,
+                     axis_id: i32,
+                     axis_value: f64,
+                     axis_list: &[Axis],
+                     prev_axis_values: &mut Vec<AxisValue>) -> (f64, f64) {
+    let prev_value_pos = prev_axis_values.iter().position(|prev_axis| {
+        prev_axis.device_id == event.sourceid &&
+            prev_axis.axis_number == axis_id
+    });
+    let delta = match prev_value_pos {
+        Some(idx) => axis_value - prev_axis_values[idx].value,
+        None => 0.0
+    };
+
+    let new_axis_value = AxisValue{
+        device_id: event.sourceid,
+        axis_number: axis_id,
+        value: axis_value
+    };
+
+    match prev_value_pos {
+        Some(idx) => prev_axis_values[idx] = new_axis_value,
+        None => prev_axis_values.push(new_axis_value)
+    }
+
+    let mut scroll_delta = (0.0, 0.0);
+
+    for axis in axis_list.iter() {
+        if axis.id == event.sourceid &&
+            axis.axis_number == axis_id {
+                match axis.axis_type {
+                    AxisType::HorizontalScroll => scroll_delta.0 = delta,
+                    AxisType::VerticalScroll => scroll_delta.1 = delta,
+                    _ => {}
+                }
+            }
+    }
+
+    scroll_delta
+}
+
+fn main () {
+    let mut demo_window = DemoWindow::new(TITLE, DEFAULT_WIDTH, DEFAULT_HEIGHT);
+
+    // query XInput support
+    let mut opcode: c_int = 0;
+    let mut event: c_int = 0;
+    let mut error: c_int = 0;
+    let xinput_str = CString::new("XInputExtension").unwrap();
+    let xinput_available = unsafe {
+        xlib::XQueryExtension(demo_window.display, xinput_str.as_ptr(), &mut opcode, &mut event, &mut error)
+    };
+    if xinput_available == xlib::False {
+        panic!("XInput not available")
+    }
+
+    let mut xinput_major_ver = xinput2::XI_2_Major;
+    let mut xinput_minor_ver = xinput2::XI_2_Minor;
+    if unsafe{xinput2::XIQueryVersion(demo_window.display,
+      &mut xinput_major_ver, &mut xinput_minor_ver)} != xlib::Success as c_int {
+        panic!("XInput2 not available");
+    }
+    println!("XI version available {}.{}", xinput_major_ver, xinput_minor_ver);
+
+    // init XInput events
+    let mut mask: [c_uchar; 1] = [0];
+    let mut input_event_mask = xinput2::XIEventMask {
+        deviceid: xinput2::XIAllMasterDevices,
+        mask_len: mask.len() as i32,
+        mask: mask.as_mut_ptr()
+    };
+    let events = &[
+        xinput2::XI_ButtonPress,
+        xinput2::XI_ButtonRelease,
+        xinput2::XI_KeyPress,
+        xinput2::XI_KeyRelease,
+        xinput2::XI_Motion
+    ];
+    for &event in events {
+        xinput2::XISetMask(&mut mask, event);
+    }
+
+    match unsafe{xinput2::XISelectEvents(demo_window.display,
+      demo_window.window, &mut input_event_mask, 1)} {
+        status if status as u8 == xlib::Success => (),
+        err => panic!("Failed to select events {:?}", err)
+    }
+
+    // Show window
+    demo_window.show();
+
+    // Main loop
+    let display = demo_window.display;
+    let axis_list = read_input_axis_info(display);
+
+    let mut prev_state = InputState{
+        cursor_pos: (0.0, 0.0),
+        axis_values: Vec::new()
+    };
+
+    demo_window.run_event_loop(|event| {
+        match event.get_type() {
+            xlib::GenericEvent => {
+                let mut cookie: xlib::XGenericEventCookie = From::from(*event);
+                if unsafe{xlib::XGetEventData(display, &mut cookie)} != xlib::True {
+                    println!("Failed to retrieve event data");
+                    return;
+                }
+                match cookie.evtype {
+                    xinput2::XI_KeyPress | xinput2::XI_KeyRelease => {
+                        let event_data: &xinput2::XIDeviceEvent = unsafe{transmute(cookie.data)};
+                        if cookie.evtype == xinput2::XI_KeyPress {
+                            if event_data.flags & xinput2::XIKeyRepeat == 0 {
+                                println!("Key {} pressed", event_data.detail);
+                            }
+                        } else {
+                            println!("Key {} released", event_data.detail);
+                        }
+                    },
+                    xinput2::XI_ButtonPress | xinput2::XI_ButtonRelease => {
+                        let event_data: &xinput2::XIDeviceEvent = unsafe{transmute(cookie.data)};
+                        if cookie.evtype == xinput2::XI_ButtonPress {
+                            println!("Button {} pressed", event_data.detail);
+                        } else {
+                            println!("Button {} released", event_data.detail);
+                        }
+                    },
+                    xinput2::XI_Motion => {
+                        let event_data: &xinput2::XIDeviceEvent = unsafe{transmute(cookie.data)};
+                        let axis_state = event_data.valuators;
+                        let mask = unsafe{ from_raw_parts(axis_state.mask, axis_state.mask_len as usize) };
+                        let mut axis_count = 0;
+
+                        let mut scroll_delta = (0.0, 0.0);
+                        for axis_id in 0..axis_state.mask_len {
+                            if xinput2::XIMaskIsSet(&mask, axis_id) {
+                                let axis_value = unsafe{*axis_state.values.offset(axis_count)};
+                                let delta = calc_scroll_deltas(event_data, axis_id, axis_value, &axis_list, &mut prev_state.axis_values);
+                                scroll_delta.0 += delta.0;
+                                scroll_delta.1 += delta.1;
+                                axis_count += 1;
+                            }
+                        }
+
+                        if scroll_delta.0.abs() > 0.0 || scroll_delta.1.abs() > 0.0 {
+                            println!("Mouse wheel/trackpad scrolled by ({}, {})", scroll_delta.0, scroll_delta.1);
+                        }
+
+                        let new_cursor_pos = (event_data.event_x, event_data.event_y);
+                        if new_cursor_pos != prev_state.cursor_pos {
+                            println!("Mouse moved to ({}, {})", new_cursor_pos.0, new_cursor_pos.1);
+                            prev_state.cursor_pos = new_cursor_pos;
+                        }
+                    },
+                    _ => ()
+                }
+                unsafe{xlib::XFreeEventData(display, &mut cookie)};
+            },
+            _ => ()
+        }
+    });
+}

--- a/src/xinput.rs
+++ b/src/xinput.rs
@@ -4,7 +4,6 @@
 
 use libc::{
   c_char,
-  c_double,
   c_int,
   c_long,
   c_short,
@@ -13,11 +12,8 @@ use libc::{
   c_ulong,
 };
 
-use ::internal::transmute_union;
-use ::xfixes::PointerBarrier;
 use ::xlib::{
   Atom,
-  Bool,
   Display,
   Time,
   XEvent,
@@ -25,13 +21,11 @@ use ::xlib::{
   XModifierKeymap,
 };
 
-
 //
 // functions
 //
 
-
-x11_link! { Xf86vmode, ["libXi.so", "libXi.so.6"],
+x11_link! { XInput, ["libXi.so", "libXi.so.6"],
   pub fn XAllowDeviceEvents (_4: *mut Display, _3: *mut XDevice, _2: c_int, _1: c_ulong) -> c_int,
   pub fn XChangeDeviceControl (_4: *mut Display, _3: *mut XDevice, _2: c_int, _1: *mut XDeviceControl) -> c_int,
   pub fn XChangeDeviceDontPropagateList (_5: *mut Display, _4: c_ulong, _3: c_int, _2: *mut c_ulong, _1: c_int) -> c_int,
@@ -62,40 +56,7 @@ x11_link! { Xf86vmode, ["libXi.so", "libXi.so.6"],
   pub fn XGrabDevice (_9: *mut Display, _8: *mut XDevice, _7: c_ulong, _6: c_int, _5: c_int, _4: *mut c_ulong, _3: c_int, _2: c_int, _1: c_ulong) -> c_int,
   pub fn XGrabDeviceButton (_11: *mut Display, _10: *mut XDevice, _9: c_uint, _8: c_uint, _7: *mut XDevice, _6: c_ulong, _5: c_int, _4: c_uint, _3: *mut c_ulong, _2: c_int, _1: c_int) -> c_int,
   pub fn XGrabDeviceKey (_11: *mut Display, _10: *mut XDevice, _9: c_uint, _8: c_uint, _7: *mut XDevice, _6: c_ulong, _5: c_int, _4: c_uint, _3: *mut c_ulong, _2: c_int, _1: c_int) -> c_int,
-  pub fn XIAllowEvents (_4: *mut Display, _3: c_int, _2: c_int, _1: c_ulong) -> c_int,
-  pub fn XIAllowTouchEvents (_5: *mut Display, _4: c_int, _3: c_uint, _2: c_ulong, _1: c_int) -> c_int,
-  pub fn XIBarrierReleasePointer (_4: *mut Display, _3: c_int, _2: c_ulong, _1: c_uint) -> (),
-  pub fn XIBarrierReleasePointers (_3: *mut Display, _2: *mut XIBarrierReleasePointerInfo, _1: c_int) -> (),
-  pub fn XIChangeHierarchy (_3: *mut Display, _2: *mut XIAnyHierarchyChangeInfo, _1: c_int) -> c_int,
-  pub fn XIChangeProperty (_8: *mut Display, _7: c_int, _6: c_ulong, _5: c_ulong, _4: c_int, _3: c_int, _2: *mut c_uchar, _1: c_int) -> (),
-  pub fn XIDefineCursor (_4: *mut Display, _3: c_int, _2: c_ulong, _1: c_ulong) -> c_int,
-  pub fn XIDeleteProperty (_3: *mut Display, _2: c_int, _1: c_ulong) -> (),
-  pub fn XIFreeDeviceInfo (_1: *mut XIDeviceInfo) -> (),
-  pub fn XIGetClientPointer (_3: *mut Display, _2: c_ulong, _1: *mut c_int) -> c_int,
-  pub fn XIGetFocus (_3: *mut Display, _2: c_int, _1: *mut c_ulong) -> c_int,
-  pub fn XIGetProperty (_12: *mut Display, _11: c_int, _10: c_ulong, _9: c_long, _8: c_long, _7: c_int, _6: c_ulong, _5: *mut c_ulong, _4: *mut c_int, _3: *mut c_ulong, _2: *mut c_ulong, _1: *mut *mut c_uchar) -> c_int,
-  pub fn XIGetSelectedEvents (_3: *mut Display, _2: c_ulong, _1: *mut c_int) -> *mut XIEventMask,
-  pub fn XIGrabButton (_11: *mut Display, _10: c_int, _9: c_int, _8: c_ulong, _7: c_ulong, _6: c_int, _5: c_int, _4: c_int, _3: *mut XIEventMask, _2: c_int, _1: *mut XIGrabModifiers) -> c_int,
-  pub fn XIGrabDevice (_9: *mut Display, _8: c_int, _7: c_ulong, _6: c_ulong, _5: c_ulong, _4: c_int, _3: c_int, _2: c_int, _1: *mut XIEventMask) -> c_int,
-  pub fn XIGrabEnter (_10: *mut Display, _9: c_int, _8: c_ulong, _7: c_ulong, _6: c_int, _5: c_int, _4: c_int, _3: *mut XIEventMask, _2: c_int, _1: *mut XIGrabModifiers) -> c_int,
-  pub fn XIGrabFocusIn (_9: *mut Display, _8: c_int, _7: c_ulong, _6: c_int, _5: c_int, _4: c_int, _3: *mut XIEventMask, _2: c_int, _1: *mut XIGrabModifiers) -> c_int,
-  pub fn XIGrabKeycode (_10: *mut Display, _9: c_int, _8: c_int, _7: c_ulong, _6: c_int, _5: c_int, _4: c_int, _3: *mut XIEventMask, _2: c_int, _1: *mut XIGrabModifiers) -> c_int,
-  pub fn XIGrabTouchBegin (_7: *mut Display, _6: c_int, _5: c_ulong, _4: c_int, _3: *mut XIEventMask, _2: c_int, _1: *mut XIGrabModifiers) -> c_int,
-  pub fn XIListProperties (_3: *mut Display, _2: c_int, _1: *mut c_int) -> *mut c_ulong,
-  pub fn XIQueryDevice (_3: *mut Display, _2: c_int, _1: *mut c_int) -> *mut XIDeviceInfo,
-  pub fn XIQueryPointer (_12: *mut Display, _11: c_int, _10: c_ulong, _9: *mut c_ulong, _8: *mut c_ulong, _7: *mut c_double, _6: *mut c_double, _5: *mut c_double, _4: *mut c_double, _3: *mut XIButtonState, _2: *mut XIModifierState, _1: *mut XIModifierState) -> c_int,
-  pub fn XIQueryVersion (_3: *mut Display, _2: *mut c_int, _1: *mut c_int) -> c_int,
-  pub fn XISelectEvents (_4: *mut Display, _3: c_ulong, _2: *mut XIEventMask, _1: c_int) -> c_int,
-  pub fn XISetClientPointer (_3: *mut Display, _2: c_ulong, _1: c_int) -> c_int,
-  pub fn XISetFocus (_4: *mut Display, _3: c_int, _2: c_ulong, _1: c_ulong) -> c_int,
-  pub fn XIUndefineCursor (_3: *mut Display, _2: c_int, _1: c_ulong) -> c_int,
-  pub fn XIUngrabButton (_6: *mut Display, _5: c_int, _4: c_int, _3: c_ulong, _2: c_int, _1: *mut XIGrabModifiers) -> c_int,
-  pub fn XIUngrabDevice (_3: *mut Display, _2: c_int, _1: c_ulong) -> c_int,
-  pub fn XIUngrabEnter (_5: *mut Display, _4: c_int, _3: c_ulong, _2: c_int, _1: *mut XIGrabModifiers) -> c_int,
-  pub fn XIUngrabFocusIn (_5: *mut Display, _4: c_int, _3: c_ulong, _2: c_int, _1: *mut XIGrabModifiers) -> c_int,
-  pub fn XIUngrabKeycode (_6: *mut Display, _5: c_int, _4: c_int, _3: c_ulong, _2: c_int, _1: *mut XIGrabModifiers) -> c_int,
-  pub fn XIUngrabTouchBegin (_5: *mut Display, _4: c_int, _3: c_ulong, _2: c_int, _1: *mut XIGrabModifiers) -> c_int,
-  pub fn XIWarpPointer (_10: *mut Display, _9: c_int, _8: c_ulong, _7: c_ulong, _6: c_double, _5: c_double, _4: c_uint, _3: c_uint, _2: c_double, _1: c_double) -> c_int,
+  
   pub fn XListDeviceProperties (_3: *mut Display, _2: *mut XDevice, _1: *mut c_int) -> *mut c_ulong,
   pub fn XListInputDevices (_2: *mut Display, _1: *mut c_int) -> *mut XDeviceInfo,
   pub fn XOpenDevice (_2: *mut Display, _1: c_ulong) -> *mut XDevice,
@@ -119,10 +80,8 @@ globals:
 // types
 //
 
-
 pub enum _XAnyClassinfo {}
 
-pub type BarrierEventID = c_uint;
 pub type XAnyClassPtr = *mut _XAnyClassinfo;
 
 #[derive(Clone, Copy, PartialEq)]
@@ -192,88 +151,6 @@ pub struct XFeedbackState {
 
 #[derive(Clone, Copy, PartialEq)]
 #[repr(C)]
-pub struct XIAddMasterInfo {
-  pub type_: c_int,
-  pub name: *mut c_char,
-  pub send_core: Bool,
-  pub enable: Bool,
-}
-
-#[derive(Clone, Copy, PartialEq)]
-#[repr(C)]
-pub struct XIAnyClassInfo {
-  pub type_: c_int,
-  pub sourceid: c_int,
-}
-
-#[derive(Clone, Copy, PartialEq)]
-#[repr(C)]
-pub struct XIAttachSlaveInfo {
-  pub type_: c_int,
-  pub deviceid: c_int,
-  pub new_master: c_int,
-}
-
-#[derive(Clone, Copy, PartialEq)]
-#[repr(C)]
-pub struct XIBarrierReleasePointerInfo {
-  pub deviceid: c_int,
-  pub barrier: PointerBarrier,
-  pub eventid: BarrierEventID,
-}
-
-#[derive(Clone, Copy, PartialEq)]
-#[repr(C)]
-pub struct XIButtonState {
-  pub mask_len: c_int,
-  pub mask: *mut c_uchar,
-}
-
-#[derive(Clone, Copy, PartialEq)]
-#[repr(C)]
-pub struct XIDetachSlaveInfo {
-  pub type_: c_int,
-  pub deviceid: c_int,
-}
-
-#[derive(Clone, Copy, PartialEq)]
-#[repr(C)]
-pub struct XIDeviceInfo {
-  pub deviceid: c_int,
-  pub name: *mut c_char,
-  pub use_: c_int,
-  pub attachment: c_int,
-  pub enabled: Bool,
-  pub num_classes: c_int,
-  pub classes: *mut *mut XIAnyClassInfo,
-}
-
-#[derive(Clone, Copy, PartialEq)]
-#[repr(C)]
-pub struct XIEventMask {
-  pub deviceid: c_int,
-  pub mask_len: c_int,
-  pub mask: *mut c_uchar,
-}
-
-#[derive(Clone, Copy, PartialEq)]
-#[repr(C)]
-pub struct XIGrabModifiers {
-  pub modifiers: c_int,
-  pub status: c_int,
-}
-
-#[derive(Clone, Copy, PartialEq)]
-#[repr(C)]
-pub struct XIModifierState {
-  pub base: c_int,
-  pub latched: c_int,
-  pub locked: c_int,
-  pub effective: c_int,
-}
-
-#[derive(Clone, Copy, PartialEq)]
-#[repr(C)]
 pub struct XInputClass {
   pub class: c_uchar,
   pub length: c_uchar,
@@ -286,90 +163,3 @@ pub struct XInputClassInfo {
   pub event_type_base: c_uchar,
 }
 
-#[derive(Clone, Copy, PartialEq)]
-#[repr(C)]
-pub struct XIRemoveMasterInfo {
-  pub type_: c_int,
-  pub deviceid: c_int,
-  pub return_mode: c_int,
-  pub return_pointer: c_int,
-  pub return_keyboard: c_int,
-}
-
-
-//
-// XIAnyHierarchyChangeInfo
-//
-
-
-#[derive(Clone, Copy, PartialEq)]
-#[repr(C)]
-pub struct XIAnyHierarchyChangeInfo {
-  type_: c_int,
-  ptr: *mut (),
-  data: [c_int; 2],
-}
-
-impl XIAnyHierarchyChangeInfo {
-  pub fn get_type (&self) -> c_int {
-    self.type_
-  }
-}
-
-impl From<XIAddMasterInfo> for XIAnyHierarchyChangeInfo {
-  fn from (other: XIAddMasterInfo) -> XIAnyHierarchyChangeInfo {
-    unsafe { transmute_union(&other) }
-  }
-}
-
-impl From<XIAnyHierarchyChangeInfo> for XIAddMasterInfo {
-  fn from (other: XIAnyHierarchyChangeInfo) -> XIAddMasterInfo {
-    unsafe { transmute_union(&other) }
-  }
-}
-
-impl From<XIAttachSlaveInfo> for XIAnyHierarchyChangeInfo {
-  fn from (other: XIAttachSlaveInfo) -> XIAnyHierarchyChangeInfo {
-    unsafe { transmute_union(&other) }
-  }
-}
-
-impl From<XIAnyHierarchyChangeInfo> for XIAttachSlaveInfo {
-  fn from (other: XIAnyHierarchyChangeInfo) -> XIAttachSlaveInfo {
-    unsafe { transmute_union(&other) }
-  }
-}
-
-impl From<XIDetachSlaveInfo> for XIAnyHierarchyChangeInfo {
-  fn from (other: XIDetachSlaveInfo) -> XIAnyHierarchyChangeInfo {
-    unsafe { transmute_union(&other) }
-  }
-}
-
-impl From<XIAnyHierarchyChangeInfo> for XIDetachSlaveInfo {
-  fn from (other: XIAnyHierarchyChangeInfo) -> XIDetachSlaveInfo {
-    unsafe { transmute_union(&other) }
-  }
-}
-
-impl From<XIRemoveMasterInfo> for XIAnyHierarchyChangeInfo {
-  fn from (other: XIRemoveMasterInfo) -> XIAnyHierarchyChangeInfo {
-    unsafe { transmute_union(&other) }
-  }
-}
-
-impl From<XIAnyHierarchyChangeInfo> for XIRemoveMasterInfo {
-  fn from (other: XIAnyHierarchyChangeInfo) -> XIRemoveMasterInfo {
-    unsafe { transmute_union(&other) }
-  }
-}
-
-#[test]
-fn hierarchy_change_info_size_test () {
-  use std::mem::size_of;
-
-  assert!(size_of::<XIAnyHierarchyChangeInfo>() >= size_of::<XIAddMasterInfo>());
-  assert!(size_of::<XIAnyHierarchyChangeInfo>() >= size_of::<XIAttachSlaveInfo>());
-  assert!(size_of::<XIAnyHierarchyChangeInfo>() >= size_of::<XIDetachSlaveInfo>());
-  assert!(size_of::<XIAnyHierarchyChangeInfo>() >= size_of::<XIRemoveMasterInfo>());
-}

--- a/src/xinput2.rs
+++ b/src/xinput2.rs
@@ -1,0 +1,757 @@
+use xfixes::PointerBarrier;
+use xlib::{Atom, Display, Time, Window};
+use libc::{c_int, c_uint, c_long, c_double, c_ulong, c_uchar};
+
+//
+// macro translations
+//
+fn mask_byte(mask_flag: i32) -> usize {
+    (mask_flag >> 3) as usize
+}
+
+pub fn XISetMask(mask: &mut [::libc::c_uchar], event: i32) {
+    mask[mask_byte(event)] |= 1 << (event & 7);
+}
+
+pub fn XIClearMask(mask: &mut [::libc::c_uchar], event: i32) {
+    mask[mask_byte(event)] &= 1 << (event & 7);
+}
+
+pub fn XIMaskIsSet(mask: &[::libc::c_uchar], event: i32) -> bool {
+    (mask[mask_byte(event)] & (1 << (event & 7))) != 0
+}
+
+//
+// functions
+//
+x11_link! { XInput2, ["libXi.so", "libXi.so.6"],
+  pub fn XIAllowEvents (_4: *mut Display, _3: c_int, _2: c_int, _1: c_ulong) -> c_int,
+  pub fn XIAllowTouchEvents (_5: *mut Display, _4: c_int, _3: c_uint, _2: c_ulong, _1: c_int) -> c_int,
+  pub fn XIBarrierReleasePointer (_4: *mut Display, _3: c_int, _2: c_ulong, _1: c_uint) -> (),
+  pub fn XIBarrierReleasePointers (_3: *mut Display, _2: *mut XIBarrierReleasePointerInfo, _1: c_int) -> (),
+  pub fn XIChangeHierarchy (_3: *mut Display, _2: *mut XIAnyHierarchyChangeInfo, _1: c_int) -> c_int,
+  pub fn XIChangeProperty (_8: *mut Display, _7: c_int, _6: c_ulong, _5: c_ulong, _4: c_int, _3: c_int, _2: *mut c_uchar, _1: c_int) -> (),
+  pub fn XIDefineCursor (_4: *mut Display, _3: c_int, _2: c_ulong, _1: c_ulong) -> c_int,
+  pub fn XIDeleteProperty (_3: *mut Display, _2: c_int, _1: c_ulong) -> (),
+  pub fn XIFreeDeviceInfo (_1: *mut XIDeviceInfo) -> (),
+  pub fn XIGetClientPointer (_3: *mut Display, _2: c_ulong, _1: *mut c_int) -> c_int,
+  pub fn XIGetFocus (_3: *mut Display, _2: c_int, _1: *mut c_ulong) -> c_int,
+  pub fn XIGetProperty (_12: *mut Display, _11: c_int, _10: c_ulong, _9: c_long, _8: c_long, _7: c_int, _6: c_ulong, _5: *mut c_ulong, _4: *mut c_int, _3: *mut c_ulong, _2: *mut c_ulong, _1: *mut *mut c_uchar) -> c_int,
+  pub fn XIGetSelectedEvents (_3: *mut Display, _2: c_ulong, _1: *mut c_int) -> *mut XIEventMask,
+  pub fn XIGrabButton (_11: *mut Display, _10: c_int, _9: c_int, _8: c_ulong, _7: c_ulong, _6: c_int, _5: c_int, _4: c_int, _3: *mut XIEventMask, _2: c_int, _1: *mut XIGrabModifiers) -> c_int,
+  pub fn XIGrabDevice (_9: *mut Display, _8: c_int, _7: c_ulong, _6: c_ulong, _5: c_ulong, _4: c_int, _3: c_int, _2: c_int, _1: *mut XIEventMask) -> c_int,
+  pub fn XIGrabEnter (_10: *mut Display, _9: c_int, _8: c_ulong, _7: c_ulong, _6: c_int, _5: c_int, _4: c_int, _3: *mut XIEventMask, _2: c_int, _1: *mut XIGrabModifiers) -> c_int,
+  pub fn XIGrabFocusIn (_9: *mut Display, _8: c_int, _7: c_ulong, _6: c_int, _5: c_int, _4: c_int, _3: *mut XIEventMask, _2: c_int, _1: *mut XIGrabModifiers) -> c_int,
+  pub fn XIGrabKeycode (_10: *mut Display, _9: c_int, _8: c_int, _7: c_ulong, _6: c_int, _5: c_int, _4: c_int, _3: *mut XIEventMask, _2: c_int, _1: *mut XIGrabModifiers) -> c_int,
+  pub fn XIGrabTouchBegin (_7: *mut Display, _6: c_int, _5: c_ulong, _4: c_int, _3: *mut XIEventMask, _2: c_int, _1: *mut XIGrabModifiers) -> c_int,
+  pub fn XIListProperties (_3: *mut Display, _2: c_int, _1: *mut c_int) -> *mut c_ulong,
+  pub fn XIQueryDevice (_3: *mut Display, _2: c_int, _1: *mut c_int) -> *mut XIDeviceInfo,
+  pub fn XIQueryPointer (_12: *mut Display, _11: c_int, _10: c_ulong, _9: *mut c_ulong, _8: *mut c_ulong, _7: *mut c_double, _6: *mut c_double, _5: *mut c_double, _4: *mut c_double, _3: *mut XIButtonState, _2: *mut XIModifierState, _1: *mut XIModifierState) -> c_int,
+  pub fn XIQueryVersion (_3: *mut Display, _2: *mut c_int, _1: *mut c_int) -> c_int,
+  pub fn XISelectEvents (_4: *mut Display, _3: c_ulong, _2: *mut XIEventMask, _1: c_int) -> c_int,
+  pub fn XISetClientPointer (_3: *mut Display, _2: c_ulong, _1: c_int) -> c_int,
+  pub fn XISetFocus (_4: *mut Display, _3: c_int, _2: c_ulong, _1: c_ulong) -> c_int,
+  pub fn XIUndefineCursor (_3: *mut Display, _2: c_int, _1: c_ulong) -> c_int,
+  pub fn XIUngrabButton (_6: *mut Display, _5: c_int, _4: c_int, _3: c_ulong, _2: c_int, _1: *mut XIGrabModifiers) -> c_int,
+  pub fn XIUngrabDevice (_3: *mut Display, _2: c_int, _1: c_ulong) -> c_int,
+  pub fn XIUngrabEnter (_5: *mut Display, _4: c_int, _3: c_ulong, _2: c_int, _1: *mut XIGrabModifiers) -> c_int,
+  pub fn XIUngrabFocusIn (_5: *mut Display, _4: c_int, _3: c_ulong, _2: c_int, _1: *mut XIGrabModifiers) -> c_int,
+  pub fn XIUngrabKeycode (_6: *mut Display, _5: c_int, _4: c_int, _3: c_ulong, _2: c_int, _1: *mut XIGrabModifiers) -> c_int,
+  pub fn XIUngrabTouchBegin (_5: *mut Display, _4: c_int, _3: c_ulong, _2: c_int, _1: *mut XIGrabModifiers) -> c_int,
+  pub fn XIWarpPointer (_10: *mut Display, _9: c_int, _8: c_ulong, _7: c_ulong, _6: c_double, _5: c_double, _4: c_uint, _3: c_uint, _2: c_double, _1: c_double) -> c_int,
+variadic:
+globals:
+}
+
+//
+// constants
+// (auto-generated with cmacros)
+//
+
+pub const XInput_2_0: i32 = 7;
+pub const XI_2_Major: i32 = 2;
+pub const XI_2_Minor: i32 = 3;
+pub const XIPropertyDeleted: i32 = 0;
+pub const XIPropertyCreated: i32 = 1;
+pub const XIPropertyModified: i32 = 2;
+pub const XIPropModeReplace: i32 = 0;
+pub const XIPropModePrepend: i32 = 1;
+pub const XIPropModeAppend: i32 = 2;
+pub const XINotifyNormal: i32 = 0;
+pub const XINotifyGrab: i32 = 1;
+pub const XINotifyUngrab: i32 = 2;
+pub const XINotifyWhileGrabbed: i32 = 3;
+pub const XINotifyPassiveGrab: i32 = 4;
+pub const XINotifyPassiveUngrab: i32 = 5;
+pub const XINotifyAncestor: i32 = 0;
+pub const XINotifyVirtual: i32 = 1;
+pub const XINotifyInferior: i32 = 2;
+pub const XINotifyNonlinear: i32 = 3;
+pub const XINotifyNonlinearVirtual: i32 = 4;
+pub const XINotifyPointer: i32 = 5;
+pub const XINotifyPointerRoot: i32 = 6;
+pub const XINotifyDetailNone: i32 = 7;
+pub const XIGrabModeSync: i32 = 0;
+pub const XIGrabModeAsync: i32 = 1;
+pub const XIGrabModeTouch: i32 = 2;
+pub const XIGrabSuccess: i32 = 0;
+pub const XIAlreadyGrabbed: i32 = 1;
+pub const XIGrabInvalidTime: i32 = 2;
+pub const XIGrabNotViewable: i32 = 3;
+pub const XIGrabFrozen: i32 = 4;
+pub const XIGrabtypeButton: i32 = 0;
+pub const XIGrabtypeKeycode: i32 = 1;
+pub const XIGrabtypeEnter: i32 = 2;
+pub const XIGrabtypeFocusIn: i32 = 3;
+pub const XIGrabtypeTouchBegin: i32 = 4;
+pub const XIAnyButton: i32 = 0;
+pub const XIAnyKeycode: i32 = 0;
+pub const XIAsyncDevice: i32 = 0;
+pub const XISyncDevice: i32 = 1;
+pub const XIReplayDevice: i32 = 2;
+pub const XIAsyncPairedDevice: i32 = 3;
+pub const XIAsyncPair: i32 = 4;
+pub const XISyncPair: i32 = 5;
+pub const XIAcceptTouch: i32 = 6;
+pub const XIRejectTouch: i32 = 7;
+pub const XISlaveSwitch: i32 = 1;
+pub const XIDeviceChange: i32 = 2;
+pub const XIMasterAdded: i32 = (1 << 0);
+pub const XIMasterRemoved: i32 = (1 << 1);
+pub const XISlaveAdded: i32 = (1 << 2);
+pub const XISlaveRemoved: i32 = (1 << 3);
+pub const XISlaveAttached: i32 = (1 << 4);
+pub const XISlaveDetached: i32 = (1 << 5);
+pub const XIDeviceEnabled: i32 = (1 << 6);
+pub const XIDeviceDisabled: i32 = (1 << 7);
+pub const XIAddMaster: i32 = 1;
+pub const XIRemoveMaster: i32 = 2;
+pub const XIAttachSlave: i32 = 3;
+pub const XIDetachSlave: i32 = 4;
+pub const XIAttachToMaster: i32 = 1;
+pub const XIFloating: i32 = 2;
+pub const XIModeRelative: i32 = 0;
+pub const XIModeAbsolute: i32 = 1;
+pub const XIMasterPointer: i32 = 1;
+pub const XIMasterKeyboard: i32 = 2;
+pub const XISlavePointer: i32 = 3;
+pub const XISlaveKeyboard: i32 = 4;
+pub const XIFloatingSlave: i32 = 5;
+pub const XIKeyClass: i32 = 0;
+pub const XIButtonClass: i32 = 1;
+pub const XIValuatorClass: i32 = 2;
+pub const XIScrollClass: i32 = 3;
+pub const XITouchClass: i32 = 8;
+pub const XIScrollTypeVertical: i32 = 1;
+pub const XIScrollTypeHorizontal: i32 = 2;
+pub const XIScrollFlagNoEmulation: i32 = (1 << 0);
+pub const XIScrollFlagPreferred: i32 = (1 << 1);
+pub const XIKeyRepeat: i32 = (1 << 16);
+pub const XIPointerEmulated: i32 = (1 << 16);
+pub const XITouchPendingEnd: i32 = (1 << 16);
+pub const XITouchEmulatingPointer: i32 = (1 << 17);
+pub const XIBarrierPointerReleased: i32 = (1 << 0);
+pub const XIBarrierDeviceIsGrabbed: i32 = (1 << 1);
+pub const XIDirectTouch: i32 = 1;
+pub const XIDependentTouch: i32 = 2;
+pub const XIAllDevices: i32 = 0;
+pub const XIAllMasterDevices: i32 = 1;
+pub const XI_DeviceChanged: i32 = 1;
+pub const XI_KeyPress: i32 = 2;
+pub const XI_KeyRelease: i32 = 3;
+pub const XI_ButtonPress: i32 = 4;
+pub const XI_ButtonRelease: i32 = 5;
+pub const XI_Motion: i32 = 6;
+pub const XI_Enter: i32 = 7;
+pub const XI_Leave: i32 = 8;
+pub const XI_FocusIn: i32 = 9;
+pub const XI_FocusOut: i32 = 10;
+pub const XI_HierarchyChanged: i32 = 11;
+pub const XI_PropertyEvent: i32 = 12;
+pub const XI_RawKeyPress: i32 = 13;
+pub const XI_RawKeyRelease: i32 = 14;
+pub const XI_RawButtonPress: i32 = 15;
+pub const XI_RawButtonRelease: i32 = 16;
+pub const XI_RawMotion: i32 = 17;
+pub const XI_TouchBegin: i32 = 18 /* XI 2.2 */;
+pub const XI_TouchUpdate: i32 = 19;
+pub const XI_TouchEnd: i32 = 20;
+pub const XI_TouchOwnership: i32 = 21;
+pub const XI_RawTouchBegin: i32 = 22;
+pub const XI_RawTouchUpdate: i32 = 23;
+pub const XI_RawTouchEnd: i32 = 24;
+pub const XI_BarrierHit: i32 = 25 /* XI 2.3 */;
+pub const XI_BarrierLeave: i32 = 26;
+pub const XI_LASTEVENT: i32 = XI_BarrierLeave;
+pub const XI_DeviceChangedMask: i32 = (1 << XI_DeviceChanged);
+pub const XI_KeyPressMask: i32 = (1 << XI_KeyPress);
+pub const XI_KeyReleaseMask: i32 = (1 << XI_KeyRelease);
+pub const XI_ButtonPressMask: i32 = (1 << XI_ButtonPress);
+pub const XI_ButtonReleaseMask: i32 = (1 << XI_ButtonRelease);
+pub const XI_MotionMask: i32 = (1 << XI_Motion);
+pub const XI_EnterMask: i32 = (1 << XI_Enter);
+pub const XI_LeaveMask: i32 = (1 << XI_Leave);
+pub const XI_FocusInMask: i32 = (1 << XI_FocusIn);
+pub const XI_FocusOutMask: i32 = (1 << XI_FocusOut);
+pub const XI_HierarchyChangedMask: i32 = (1 << XI_HierarchyChanged);
+pub const XI_PropertyEventMask: i32 = (1 << XI_PropertyEvent);
+pub const XI_RawKeyPressMask: i32 = (1 << XI_RawKeyPress);
+pub const XI_RawKeyReleaseMask: i32 = (1 << XI_RawKeyRelease);
+pub const XI_RawButtonPressMask: i32 = (1 << XI_RawButtonPress);
+pub const XI_RawButtonReleaseMask: i32 = (1 << XI_RawButtonRelease);
+pub const XI_RawMotionMask: i32 = (1 << XI_RawMotion);
+pub const XI_TouchBeginMask: i32 = (1 << XI_TouchBegin);
+pub const XI_TouchEndMask: i32 = (1 << XI_TouchEnd);
+pub const XI_TouchOwnershipChangedMask: i32 = (1 << XI_TouchOwnership);
+pub const XI_TouchUpdateMask: i32 = (1 << XI_TouchUpdate);
+pub const XI_RawTouchBeginMask: i32 = (1 << XI_RawTouchBegin);
+pub const XI_RawTouchEndMask: i32 = (1 << XI_RawTouchEnd);
+pub const XI_RawTouchUpdateMask: i32 = (1 << XI_RawTouchUpdate);
+pub const XI_BarrierHitMask: i32 = (1 << XI_BarrierHit);
+pub const XI_BarrierLeaveMask: i32 = (1 << XI_BarrierLeave);
+
+//
+// structs
+// (auto-generated with rust-bindgen)
+//
+
+#[repr(C)]
+#[derive(Copy)]
+pub struct Struct_Unnamed1 {
+    pub _type: ::libc::c_int,
+    pub name: *mut ::libc::c_char,
+    pub send_core: ::libc::c_int,
+    pub enable: ::libc::c_int,
+}
+impl ::std::clone::Clone for Struct_Unnamed1 {
+    fn clone(&self) -> Self { *self }
+}
+impl ::std::default::Default for Struct_Unnamed1 {
+    fn default() -> Self { unsafe { ::std::mem::zeroed() } }
+}
+pub type XIAddMasterInfo = Struct_Unnamed1;
+#[repr(C)]
+#[derive(Copy)]
+pub struct Struct_Unnamed2 {
+    pub _type: ::libc::c_int,
+    pub deviceid: ::libc::c_int,
+    pub return_mode: ::libc::c_int,
+    pub return_pointer: ::libc::c_int,
+    pub return_keyboard: ::libc::c_int,
+}
+impl ::std::clone::Clone for Struct_Unnamed2 {
+    fn clone(&self) -> Self { *self }
+}
+impl ::std::default::Default for Struct_Unnamed2 {
+    fn default() -> Self { unsafe { ::std::mem::zeroed() } }
+}
+pub type XIRemoveMasterInfo = Struct_Unnamed2;
+#[repr(C)]
+#[derive(Copy)]
+pub struct Struct_Unnamed3 {
+    pub _type: ::libc::c_int,
+    pub deviceid: ::libc::c_int,
+    pub new_master: ::libc::c_int,
+}
+impl ::std::clone::Clone for Struct_Unnamed3 {
+    fn clone(&self) -> Self { *self }
+}
+impl ::std::default::Default for Struct_Unnamed3 {
+    fn default() -> Self { unsafe { ::std::mem::zeroed() } }
+}
+pub type XIAttachSlaveInfo = Struct_Unnamed3;
+#[repr(C)]
+#[derive(Copy)]
+pub struct Struct_Unnamed4 {
+    pub _type: ::libc::c_int,
+    pub deviceid: ::libc::c_int,
+}
+impl ::std::clone::Clone for Struct_Unnamed4 {
+    fn clone(&self) -> Self { *self }
+}
+impl ::std::default::Default for Struct_Unnamed4 {
+    fn default() -> Self { unsafe { ::std::mem::zeroed() } }
+}
+pub type XIDetachSlaveInfo = Struct_Unnamed4;
+#[repr(C)]
+#[derive(Copy)]
+pub struct Union_Unnamed5 {
+    pub _bindgen_data_: [u64; 3usize],
+}
+impl Union_Unnamed5 {
+    pub unsafe fn _type(&mut self) -> *mut ::libc::c_int {
+        let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_);
+        ::std::mem::transmute(raw.offset(0))
+    }
+    pub unsafe fn add(&mut self) -> *mut XIAddMasterInfo {
+        let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_);
+        ::std::mem::transmute(raw.offset(0))
+    }
+    pub unsafe fn remove(&mut self) -> *mut XIRemoveMasterInfo {
+        let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_);
+        ::std::mem::transmute(raw.offset(0))
+    }
+    pub unsafe fn attach(&mut self) -> *mut XIAttachSlaveInfo {
+        let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_);
+        ::std::mem::transmute(raw.offset(0))
+    }
+    pub unsafe fn detach(&mut self) -> *mut XIDetachSlaveInfo {
+        let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_);
+        ::std::mem::transmute(raw.offset(0))
+    }
+}
+impl ::std::clone::Clone for Union_Unnamed5 {
+    fn clone(&self) -> Self { *self }
+}
+impl ::std::default::Default for Union_Unnamed5 {
+    fn default() -> Self { unsafe { ::std::mem::zeroed() } }
+}
+pub type XIAnyHierarchyChangeInfo = Union_Unnamed5;
+#[repr(C)]
+#[derive(Copy)]
+pub struct Struct_Unnamed6 {
+    pub base: ::libc::c_int,
+    pub latched: ::libc::c_int,
+    pub locked: ::libc::c_int,
+    pub effective: ::libc::c_int,
+}
+impl ::std::clone::Clone for Struct_Unnamed6 {
+    fn clone(&self) -> Self { *self }
+}
+impl ::std::default::Default for Struct_Unnamed6 {
+    fn default() -> Self { unsafe { ::std::mem::zeroed() } }
+}
+pub type XIModifierState = Struct_Unnamed6;
+pub type XIGroupState = XIModifierState;
+#[repr(C)]
+#[derive(Copy)]
+pub struct Struct_Unnamed7 {
+    pub mask_len: ::libc::c_int,
+    pub mask: *mut ::libc::c_uchar,
+}
+impl ::std::clone::Clone for Struct_Unnamed7 {
+    fn clone(&self) -> Self { *self }
+}
+impl ::std::default::Default for Struct_Unnamed7 {
+    fn default() -> Self { unsafe { ::std::mem::zeroed() } }
+}
+pub type XIButtonState = Struct_Unnamed7;
+#[repr(C)]
+#[derive(Copy)]
+pub struct Struct_Unnamed8 {
+    pub mask_len: ::libc::c_int,
+    pub mask: *mut ::libc::c_uchar,
+    pub values: *mut ::libc::c_double,
+}
+impl ::std::clone::Clone for Struct_Unnamed8 {
+    fn clone(&self) -> Self { *self }
+}
+impl ::std::default::Default for Struct_Unnamed8 {
+    fn default() -> Self { unsafe { ::std::mem::zeroed() } }
+}
+pub type XIValuatorState = Struct_Unnamed8;
+#[repr(C)]
+#[derive(Copy)]
+pub struct Struct_Unnamed9 {
+    pub deviceid: ::libc::c_int,
+    pub mask_len: ::libc::c_int,
+    pub mask: *mut ::libc::c_uchar,
+}
+impl ::std::clone::Clone for Struct_Unnamed9 {
+    fn clone(&self) -> Self { *self }
+}
+impl ::std::default::Default for Struct_Unnamed9 {
+    fn default() -> Self { unsafe { ::std::mem::zeroed() } }
+}
+pub type XIEventMask = Struct_Unnamed9;
+#[repr(C)]
+#[derive(Copy)]
+pub struct Struct_Unnamed10 {
+    pub _type: ::libc::c_int,
+    pub sourceid: ::libc::c_int,
+}
+impl ::std::clone::Clone for Struct_Unnamed10 {
+    fn clone(&self) -> Self { *self }
+}
+impl ::std::default::Default for Struct_Unnamed10 {
+    fn default() -> Self { unsafe { ::std::mem::zeroed() } }
+}
+pub type XIAnyClassInfo = Struct_Unnamed10;
+#[repr(C)]
+#[derive(Copy)]
+pub struct Struct_Unnamed11 {
+    pub _type: ::libc::c_int,
+    pub sourceid: ::libc::c_int,
+    pub num_buttons: ::libc::c_int,
+    pub labels: *mut Atom,
+    pub state: XIButtonState,
+}
+impl ::std::clone::Clone for Struct_Unnamed11 {
+    fn clone(&self) -> Self { *self }
+}
+impl ::std::default::Default for Struct_Unnamed11 {
+    fn default() -> Self { unsafe { ::std::mem::zeroed() } }
+}
+pub type XIButtonClassInfo = Struct_Unnamed11;
+#[repr(C)]
+#[derive(Copy)]
+pub struct Struct_Unnamed12 {
+    pub _type: ::libc::c_int,
+    pub sourceid: ::libc::c_int,
+    pub num_keycodes: ::libc::c_int,
+    pub keycodes: *mut ::libc::c_int,
+}
+impl ::std::clone::Clone for Struct_Unnamed12 {
+    fn clone(&self) -> Self { *self }
+}
+impl ::std::default::Default for Struct_Unnamed12 {
+    fn default() -> Self { unsafe { ::std::mem::zeroed() } }
+}
+pub type XIKeyClassInfo = Struct_Unnamed12;
+#[repr(C)]
+#[derive(Copy)]
+pub struct Struct_Unnamed13 {
+    pub _type: ::libc::c_int,
+    pub sourceid: ::libc::c_int,
+    pub number: ::libc::c_int,
+    pub label: Atom,
+    pub min: ::libc::c_double,
+    pub max: ::libc::c_double,
+    pub value: ::libc::c_double,
+    pub resolution: ::libc::c_int,
+    pub mode: ::libc::c_int,
+}
+impl ::std::clone::Clone for Struct_Unnamed13 {
+    fn clone(&self) -> Self { *self }
+}
+impl ::std::default::Default for Struct_Unnamed13 {
+    fn default() -> Self { unsafe { ::std::mem::zeroed() } }
+}
+pub type XIValuatorClassInfo = Struct_Unnamed13;
+#[repr(C)]
+#[derive(Copy)]
+pub struct Struct_Unnamed14 {
+    pub _type: ::libc::c_int,
+    pub sourceid: ::libc::c_int,
+    pub number: ::libc::c_int,
+    pub scroll_type: ::libc::c_int,
+    pub increment: ::libc::c_double,
+    pub flags: ::libc::c_int,
+}
+impl ::std::clone::Clone for Struct_Unnamed14 {
+    fn clone(&self) -> Self { *self }
+}
+impl ::std::default::Default for Struct_Unnamed14 {
+    fn default() -> Self { unsafe { ::std::mem::zeroed() } }
+}
+pub type XIScrollClassInfo = Struct_Unnamed14;
+#[repr(C)]
+#[derive(Copy)]
+pub struct Struct_Unnamed15 {
+    pub _type: ::libc::c_int,
+    pub sourceid: ::libc::c_int,
+    pub mode: ::libc::c_int,
+    pub num_touches: ::libc::c_int,
+}
+impl ::std::clone::Clone for Struct_Unnamed15 {
+    fn clone(&self) -> Self { *self }
+}
+impl ::std::default::Default for Struct_Unnamed15 {
+    fn default() -> Self { unsafe { ::std::mem::zeroed() } }
+}
+pub type XITouchClassInfo = Struct_Unnamed15;
+#[repr(C)]
+#[derive(Copy)]
+pub struct Struct_Unnamed16 {
+    pub deviceid: ::libc::c_int,
+    pub name: *mut ::libc::c_char,
+    pub _use: ::libc::c_int,
+    pub attachment: ::libc::c_int,
+    pub enabled: ::libc::c_int,
+    pub num_classes: ::libc::c_int,
+    pub classes: *mut *mut XIAnyClassInfo,
+}
+impl ::std::clone::Clone for Struct_Unnamed16 {
+    fn clone(&self) -> Self { *self }
+}
+impl ::std::default::Default for Struct_Unnamed16 {
+    fn default() -> Self { unsafe { ::std::mem::zeroed() } }
+}
+pub type XIDeviceInfo = Struct_Unnamed16;
+#[repr(C)]
+#[derive(Copy)]
+pub struct Struct_Unnamed17 {
+    pub modifiers: ::libc::c_int,
+    pub status: ::libc::c_int,
+}
+impl ::std::clone::Clone for Struct_Unnamed17 {
+    fn clone(&self) -> Self { *self }
+}
+impl ::std::default::Default for Struct_Unnamed17 {
+    fn default() -> Self { unsafe { ::std::mem::zeroed() } }
+}
+pub type XIGrabModifiers = Struct_Unnamed17;
+pub type BarrierEventID = ::libc::c_uint;
+#[repr(C)]
+#[derive(Copy)]
+pub struct Struct_Unnamed18 {
+    pub deviceid: ::libc::c_int,
+    pub barrier: PointerBarrier,
+    pub eventid: BarrierEventID,
+}
+impl ::std::clone::Clone for Struct_Unnamed18 {
+    fn clone(&self) -> Self { *self }
+}
+impl ::std::default::Default for Struct_Unnamed18 {
+    fn default() -> Self { unsafe { ::std::mem::zeroed() } }
+}
+pub type XIBarrierReleasePointerInfo = Struct_Unnamed18;
+#[repr(C)]
+#[derive(Copy)]
+pub struct Struct_Unnamed19 {
+    pub _type: ::libc::c_int,
+    pub serial: ::libc::c_ulong,
+    pub send_event: ::libc::c_int,
+    pub display: *mut Display,
+    pub extension: ::libc::c_int,
+    pub evtype: ::libc::c_int,
+    pub time: Time,
+}
+impl ::std::clone::Clone for Struct_Unnamed19 {
+    fn clone(&self) -> Self { *self }
+}
+impl ::std::default::Default for Struct_Unnamed19 {
+    fn default() -> Self { unsafe { ::std::mem::zeroed() } }
+}
+pub type XIEvent = Struct_Unnamed19;
+#[repr(C)]
+#[derive(Copy)]
+pub struct Struct_Unnamed20 {
+    pub deviceid: ::libc::c_int,
+    pub attachment: ::libc::c_int,
+    pub _use: ::libc::c_int,
+    pub enabled: ::libc::c_int,
+    pub flags: ::libc::c_int,
+}
+impl ::std::clone::Clone for Struct_Unnamed20 {
+    fn clone(&self) -> Self { *self }
+}
+impl ::std::default::Default for Struct_Unnamed20 {
+    fn default() -> Self { unsafe { ::std::mem::zeroed() } }
+}
+pub type XIHierarchyInfo = Struct_Unnamed20;
+#[repr(C)]
+#[derive(Copy)]
+pub struct Struct_Unnamed21 {
+    pub _type: ::libc::c_int,
+    pub serial: ::libc::c_ulong,
+    pub send_event: ::libc::c_int,
+    pub display: *mut Display,
+    pub extension: ::libc::c_int,
+    pub evtype: ::libc::c_int,
+    pub time: Time,
+    pub flags: ::libc::c_int,
+    pub num_info: ::libc::c_int,
+    pub info: *mut XIHierarchyInfo,
+}
+impl ::std::clone::Clone for Struct_Unnamed21 {
+    fn clone(&self) -> Self { *self }
+}
+impl ::std::default::Default for Struct_Unnamed21 {
+    fn default() -> Self { unsafe { ::std::mem::zeroed() } }
+}
+pub type XIHierarchyEvent = Struct_Unnamed21;
+#[repr(C)]
+#[derive(Copy)]
+pub struct Struct_Unnamed22 {
+    pub _type: ::libc::c_int,
+    pub serial: ::libc::c_ulong,
+    pub send_event: ::libc::c_int,
+    pub display: *mut Display,
+    pub extension: ::libc::c_int,
+    pub evtype: ::libc::c_int,
+    pub time: Time,
+    pub deviceid: ::libc::c_int,
+    pub sourceid: ::libc::c_int,
+    pub reason: ::libc::c_int,
+    pub num_classes: ::libc::c_int,
+    pub classes: *mut *mut XIAnyClassInfo,
+}
+impl ::std::clone::Clone for Struct_Unnamed22 {
+    fn clone(&self) -> Self { *self }
+}
+impl ::std::default::Default for Struct_Unnamed22 {
+    fn default() -> Self { unsafe { ::std::mem::zeroed() } }
+}
+pub type XIDeviceChangedEvent = Struct_Unnamed22;
+#[repr(C)]
+#[derive(Copy)]
+pub struct Struct_Unnamed23 {
+    pub _type: ::libc::c_int,
+    pub serial: ::libc::c_ulong,
+    pub send_event: ::libc::c_int,
+    pub display: *mut Display,
+    pub extension: ::libc::c_int,
+    pub evtype: ::libc::c_int,
+    pub time: Time,
+    pub deviceid: ::libc::c_int,
+    pub sourceid: ::libc::c_int,
+    pub detail: ::libc::c_int,
+    pub root: Window,
+    pub event: Window,
+    pub child: Window,
+    pub root_x: ::libc::c_double,
+    pub root_y: ::libc::c_double,
+    pub event_x: ::libc::c_double,
+    pub event_y: ::libc::c_double,
+    pub flags: ::libc::c_int,
+    pub buttons: XIButtonState,
+    pub valuators: XIValuatorState,
+    pub mods: XIModifierState,
+    pub group: XIGroupState,
+}
+impl ::std::clone::Clone for Struct_Unnamed23 {
+    fn clone(&self) -> Self { *self }
+}
+impl ::std::default::Default for Struct_Unnamed23 {
+    fn default() -> Self { unsafe { ::std::mem::zeroed() } }
+}
+pub type XIDeviceEvent = Struct_Unnamed23;
+#[repr(C)]
+#[derive(Copy)]
+pub struct Struct_Unnamed24 {
+    pub _type: ::libc::c_int,
+    pub serial: ::libc::c_ulong,
+    pub send_event: ::libc::c_int,
+    pub display: *mut Display,
+    pub extension: ::libc::c_int,
+    pub evtype: ::libc::c_int,
+    pub time: Time,
+    pub deviceid: ::libc::c_int,
+    pub sourceid: ::libc::c_int,
+    pub detail: ::libc::c_int,
+    pub flags: ::libc::c_int,
+    pub valuators: XIValuatorState,
+    pub raw_values: *mut ::libc::c_double,
+}
+impl ::std::clone::Clone for Struct_Unnamed24 {
+    fn clone(&self) -> Self { *self }
+}
+impl ::std::default::Default for Struct_Unnamed24 {
+    fn default() -> Self { unsafe { ::std::mem::zeroed() } }
+}
+pub type XIRawEvent = Struct_Unnamed24;
+#[repr(C)]
+#[derive(Copy)]
+pub struct Struct_Unnamed25 {
+    pub _type: ::libc::c_int,
+    pub serial: ::libc::c_ulong,
+    pub send_event: ::libc::c_int,
+    pub display: *mut Display,
+    pub extension: ::libc::c_int,
+    pub evtype: ::libc::c_int,
+    pub time: Time,
+    pub deviceid: ::libc::c_int,
+    pub sourceid: ::libc::c_int,
+    pub detail: ::libc::c_int,
+    pub root: Window,
+    pub event: Window,
+    pub child: Window,
+    pub root_x: ::libc::c_double,
+    pub root_y: ::libc::c_double,
+    pub event_x: ::libc::c_double,
+    pub event_y: ::libc::c_double,
+    pub mode: ::libc::c_int,
+    pub focus: ::libc::c_int,
+    pub same_screen: ::libc::c_int,
+    pub buttons: XIButtonState,
+    pub mods: XIModifierState,
+    pub group: XIGroupState,
+}
+impl ::std::clone::Clone for Struct_Unnamed25 {
+    fn clone(&self) -> Self { *self }
+}
+impl ::std::default::Default for Struct_Unnamed25 {
+    fn default() -> Self { unsafe { ::std::mem::zeroed() } }
+}
+pub type XIEnterEvent = Struct_Unnamed25;
+pub type XILeaveEvent = XIEnterEvent;
+pub type XIFocusInEvent = XIEnterEvent;
+pub type XIFocusOutEvent = XIEnterEvent;
+#[repr(C)]
+#[derive(Copy)]
+pub struct Struct_Unnamed26 {
+    pub _type: ::libc::c_int,
+    pub serial: ::libc::c_ulong,
+    pub send_event: ::libc::c_int,
+    pub display: *mut Display,
+    pub extension: ::libc::c_int,
+    pub evtype: ::libc::c_int,
+    pub time: Time,
+    pub deviceid: ::libc::c_int,
+    pub property: Atom,
+    pub what: ::libc::c_int,
+}
+impl ::std::clone::Clone for Struct_Unnamed26 {
+    fn clone(&self) -> Self { *self }
+}
+impl ::std::default::Default for Struct_Unnamed26 {
+    fn default() -> Self { unsafe { ::std::mem::zeroed() } }
+}
+pub type XIPropertyEvent = Struct_Unnamed26;
+#[repr(C)]
+#[derive(Copy)]
+pub struct Struct_Unnamed27 {
+    pub _type: ::libc::c_int,
+    pub serial: ::libc::c_ulong,
+    pub send_event: ::libc::c_int,
+    pub display: *mut Display,
+    pub extension: ::libc::c_int,
+    pub evtype: ::libc::c_int,
+    pub time: Time,
+    pub deviceid: ::libc::c_int,
+    pub sourceid: ::libc::c_int,
+    pub touchid: ::libc::c_uint,
+    pub root: Window,
+    pub event: Window,
+    pub child: Window,
+    pub flags: ::libc::c_int,
+}
+impl ::std::clone::Clone for Struct_Unnamed27 {
+    fn clone(&self) -> Self { *self }
+}
+impl ::std::default::Default for Struct_Unnamed27 {
+    fn default() -> Self { unsafe { ::std::mem::zeroed() } }
+}
+pub type XITouchOwnershipEvent = Struct_Unnamed27;
+#[repr(C)]
+#[derive(Copy)]
+pub struct Struct_Unnamed28 {
+    pub _type: ::libc::c_int,
+    pub serial: ::libc::c_ulong,
+    pub send_event: ::libc::c_int,
+    pub display: *mut Display,
+    pub extension: ::libc::c_int,
+    pub evtype: ::libc::c_int,
+    pub time: Time,
+    pub deviceid: ::libc::c_int,
+    pub sourceid: ::libc::c_int,
+    pub event: Window,
+    pub root: Window,
+    pub root_x: ::libc::c_double,
+    pub root_y: ::libc::c_double,
+    pub dx: ::libc::c_double,
+    pub dy: ::libc::c_double,
+    pub dtime: ::libc::c_int,
+    pub flags: ::libc::c_int,
+    pub barrier: PointerBarrier,
+    pub eventid: BarrierEventID,
+}
+impl ::std::clone::Clone for Struct_Unnamed28 {
+    fn clone(&self) -> Self { *self }
+}
+impl ::std::default::Default for Struct_Unnamed28 {
+    fn default() -> Self { unsafe { ::std::mem::zeroed() } }
+}
+pub type XIBarrierEvent = Struct_Unnamed28;
+

--- a/src/xlib.rs
+++ b/src/xlib.rs
@@ -2117,6 +2117,12 @@ pub struct XGenericEventCookie {
   pub data: *mut c_void,
 }
 
+impl From<XEvent> for XGenericEventCookie {
+  fn from (e: XEvent) -> XGenericEventCookie {
+    unsafe { transmute_union(&e) }
+  }
+}
+
 #[derive(Clone, Copy, PartialEq)]
 #[repr(C)]
 pub struct XHostAddress {
@@ -2663,6 +2669,7 @@ pub const SelectionNotify: c_int = 31;
 pub const ColormapNotify: c_int = 32;
 pub const ClientMessage: c_int = 33;
 pub const MappingNotify: c_int = 34;
+pub const GenericEvent: c_int = 35;
 
 // event mask
 pub const NoEventMask: c_long = 0;

--- a/x11-dl/src/lib.rs
+++ b/x11-dl/src/lib.rs
@@ -23,6 +23,7 @@ pub mod xf86vmode;
 pub mod xfixes;
 pub mod xinerama;
 pub mod xinput;
+pub mod xinput2;
 pub mod xlib;
 pub mod xmu;
 pub mod xrender;

--- a/x11-dl/src/xinput2.rs
+++ b/x11-dl/src/xinput2.rs
@@ -1,0 +1,1 @@
+../../src/xinput2.rs

--- a/x11/src/lib.rs
+++ b/x11/src/lib.rs
@@ -20,6 +20,7 @@ pub mod xf86vmode;
 pub mod xfixes;
 pub mod xinerama;
 pub mod xinput;
+pub mod xinput2;
 pub mod xlib;
 pub mod xmu;
 pub mod xrender;

--- a/x11/src/xinput2.rs
+++ b/x11/src/xinput2.rs
@@ -1,0 +1,1 @@
+../../src/xinput2.rs


### PR DESCRIPTION
This adds bindings for XInput2 structs and functions plus translations of the constants and macros defined in XInput2, plus an example app that uses the bindings.

This PR has just the bindings in the style of the other modules and no changes to the build system.

I'd like to use these changes upstream in Glutin to enable smoother scrolling and other enhancements under X11. See https://github.com/tomaka/glutin/pull/510