### PR TITLE
Changes to xrecord

### DIFF
--- a/examples/xrecord/.gitignore
+++ b/examples/xrecord/.gitignore
@@ -1,0 +1,2 @@
+Cargo.lock
+target

--- a/examples/xrecord/Cargo.toml
+++ b/examples/xrecord/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "_"
+version = "0.0.0"
+
+[dependencies]
+libc = "*"
+
+[dependencies.x11]
+path = "../../x11"
+features = ["xlib", "xrecord"]
+
+[[bin]]
+name = "_"
+path = "main.rs"

--- a/examples/xrecord/Cargo.toml
+++ b/examples/xrecord/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "_"
+name = "x11-xrecord"
 version = "0.0.0"
 
 [dependencies]
@@ -10,5 +10,5 @@ path = "../../x11"
 features = ["xlib", "xrecord"]
 
 [[bin]]
-name = "_"
+name = "x11-xrecord"
 path = "main.rs"

--- a/examples/xrecord/main.rs
+++ b/examples/xrecord/main.rs
@@ -1,0 +1,118 @@
+// Example for X Record Extension
+
+extern crate libc;
+extern crate x11;
+
+use std::ffi::CString;
+use std::ptr::{
+  null,
+  null_mut,
+};
+
+use libc::{
+    c_int
+};
+use x11::xlib;
+use x11::xrecord;
+
+static mut event_count:u32 = 0;
+
+fn main () {
+    unsafe {
+        // Open displays
+        let dpy_control = xlib::XOpenDisplay(null());
+        let dpy_data = xlib::XOpenDisplay(null());
+        if dpy_control == null_mut() || dpy_data == null_mut() {
+            panic!("can't open display");
+        }
+        // Enable synchronization
+        xlib::XSynchronize(dpy_control, 1);
+
+        let extension_name = CString::new("RECORD").unwrap();
+        
+        let extension = xlib::XInitExtension(
+            dpy_control,
+            extension_name.as_ptr());
+        if extension.is_null() {
+            panic!("Error init X Record Extension");
+        }
+
+        // Get version
+        let mut version_major: c_int = 0;
+        let mut version_minor: c_int = 0;
+        xrecord::XRecordQueryVersion(
+            dpy_control,
+            &mut version_major,
+            &mut version_minor
+        );
+        println!(
+            "RECORD extension version {}.{}",
+            version_major,
+            version_minor
+        );
+
+        // Prepare record range
+        let mut record_range: xrecord::XRecordRange = *xrecord::XRecordAllocRange();
+        record_range.device_events.first = xlib::KeyPress as u8;
+        record_range.device_events.last = xlib::MotionNotify as u8;
+
+        // Create context
+        let context = xrecord::XRecordCreateContext(
+            dpy_control,
+            0,
+            &mut xrecord::XRecordAllClients,
+            1,
+            std::mem::transmute(&mut &mut record_range),
+            1
+        );
+
+        if context == 0 {
+            panic!("Fail create Record context\n");
+        }
+
+        // Run
+        let result = xrecord::XRecordEnableContext(
+            dpy_data,
+            context,
+            Some(record_callback),
+            &mut 0
+        );
+        if result == 0 {
+            panic!("Cound not enable the Record context!\n");
+        }
+    }
+}
+
+unsafe extern "C" fn record_callback(pointer:*mut i8, raw_data: *mut xrecord::XRecordInterceptData) {
+    event_count += 1;
+    let data = &*raw_data;
+
+    // Skip server events
+    if data.category != xrecord::XRecordFromServer {
+        return;
+    }   
+
+    // Cast binary data
+    let xdatum = &*(data.data as *mut XRecordDatum);
+
+    let event_type = match xdatum.xtype  as i32 {
+        xlib::KeyPress      => "KeyPress",
+        xlib::KeyRelease    => "KeyRelease",
+        xlib::ButtonPress   => "ButtonPress",
+        xlib::ButtonRelease => "ButtonRelease",
+        xlib::MotionNotify  => "MotionNotify",
+        _                   => "Other"
+    };
+
+    println!("Event recieve\t{:?}\tevent.", event_type);
+    
+    xrecord::XRecordFreeData(raw_data);
+}
+
+#[repr(C)]
+struct XRecordDatum {
+    xtype: u8,
+    code: u8,
+    unknown1: u8,
+    unknown2: u8
+}

--- a/src/xrecord.rs
+++ b/src/xrecord.rs
@@ -44,6 +44,27 @@ globals:
 
 
 //
+// constants
+//
+
+
+pub const XRecordFromServerTime: c_int = 0x01;
+pub const XRecordFromClientTime: c_int = 0x02;
+pub const XRecordFromClientSequence: c_int = 0x04;
+
+pub const XRecordCurrentClients: c_ulong = 1;
+pub const XRecordFutureClients: c_ulong = 2;
+pub const XRecordAllClients: c_ulong = 3;
+
+pub const XRecordFromServer: c_int = 0;
+pub const XRecordFromClient: c_int = 1;
+pub const XRecordClientStarted: c_int = 2;
+pub const XRecordClientDied: c_int = 3;
+pub const XRecordStartOfData: c_int = 4;
+pub const XRecordEndOfData: c_int = 5;
+
+
+//
 // types
 //
 


### PR DESCRIPTION
Add constants definition from `X11/extensions/recordconst.h`.
Add example code using X Record Extension.
