### PR TITLE
Make ClientMessageData instantiable

### DIFF
--- a/src/xlib.rs
+++ b/src/xlib.rs
@@ -2450,6 +2450,10 @@ pub struct ClientMessageData {
 }
 
 impl ClientMessageData {
+  pub fn new() -> ClientMessageData {
+    ClientMessageData { longs: [0; 5] }
+  }
+
   pub fn get_byte (&self, index: usize) -> c_char {
     unsafe {
       from_raw_parts(&self.longs[0] as *const c_long as *const c_char, 20)[index]


### PR DESCRIPTION
`ClientMessageData` is currently uninstantiable. I've added a static `new` function, though I understand if you don't think that's the right way of fixing this.