### PR TITLE
Implement conversion traits for c_schar and c_uchar

### DIFF
--- a/src/xlib.rs
+++ b/src/xlib.rs
@@ -10,6 +10,7 @@ use std::os::raw::{
   c_int,
   c_long,
   c_short,
+  c_schar,
   c_uchar,
   c_uint,
   c_ulong,
@@ -2202,7 +2203,7 @@ macro_rules! client_message_data_conversions {
 }
 
 client_message_data_conversions! {
-  c_char[20],
+  c_schar[20],
   c_uchar[20],
   c_short[10],
   c_ushort[10],


### PR DESCRIPTION
This fixes a build error on platfoms like ARM where c_char and c_uchar are the same type.  (The C standard doesn't specify whether `char` is the same as `signed char` or `unsigned char`.)