### PR TITLE
x11-dl: fallback to pkg-config libdir for loading

### DIFF
--- a/src/dpms.rs
+++ b/src/dpms.rs
@@ -13,7 +13,7 @@ use xmd::{ CARD16, BOOL };
 //
 
 
-x11_link! { Xext, ["libXext.so.6", "libXext.so"], 9,
+x11_link! { Xext, xext, ["libXext.so.6", "libXext.so"], 9,
   pub fn DPMSQueryExtension (_1: *mut Display, _2: *mut c_int, _3: *mut c_int) -> Bool,
   pub fn DPMSGetVersion (_1: *mut Display, _2: *mut c_int, _3: *mut c_int) -> Status,
   pub fn DPMSCapable (_1: *mut Display) -> Bool,

--- a/src/glx.rs
+++ b/src/glx.rs
@@ -22,7 +22,7 @@ use ::xlib::{
 //
 
 
-x11_link! { Glx, ["libGL.so.1", "libGL.so"], 39,
+x11_link! { Glx, gl, ["libGL.so.1", "libGL.so"], 39,
   pub fn glXChooseFBConfig (_4: *mut Display, _3: c_int, _2: *const c_int, _1: *mut c_int) -> *mut GLXFBConfig,
   pub fn glXChooseVisual (_3: *mut Display, _2: c_int, _1: *mut c_int) -> *mut XVisualInfo,
   pub fn glXCopyContext (_4: *mut Display, _3: GLXContext, _2: GLXContext, _1: c_ulong) -> (),

--- a/src/xcursor.rs
+++ b/src/xcursor.rs
@@ -26,7 +26,7 @@ use ::xlib::{
 //
 
 
-x11_link! { Xcursor, ["libXcursor.so.1", "libXcursor.so"], 59,
+x11_link! { Xcursor, xcursor, ["libXcursor.so.1", "libXcursor.so"], 59,
   pub fn XcursorAnimateCreate (_1: *mut XcursorCursors) -> *mut XcursorAnimate,
   pub fn XcursorAnimateDestroy (_1: *mut XcursorAnimate) -> (),
   pub fn XcursorAnimateNext (_1: *mut XcursorAnimate) -> c_ulong,

--- a/src/xf86vmode.rs
+++ b/src/xf86vmode.rs
@@ -29,7 +29,7 @@ use ::xlib::{
 //
 
 
-x11_link! { Xf86vmode, ["libXxf86vm.so.1", "libXxf86vm.so"], 22,
+x11_link! { Xf86vmode, xxf86vm, ["libXxf86vm.so.1", "libXxf86vm.so"], 22,
   pub fn XF86VidModeAddModeLine (_4: *mut Display, _3: c_int, _2: *mut XF86VidModeModeInfo, _1: *mut XF86VidModeModeInfo) -> c_int,
   pub fn XF86VidModeDeleteModeLine (_3: *mut Display, _2: c_int, _1: *mut XF86VidModeModeInfo) -> c_int,
   pub fn XF86VidModeGetAllModeLines (_4: *mut Display, _3: c_int, _2: *mut c_int, _1: *mut *mut *mut XF86VidModeModeInfo) -> c_int,

--- a/src/xft.rs
+++ b/src/xft.rs
@@ -34,7 +34,7 @@ pub enum FcResult { Match, NoMatch, TypeMismatch, NoId, OutOfMemory }
 //
 
 
-x11_link! { Xft, ["libXft.so.2", "libXft.so"], 77,
+x11_link! { Xft, xft, ["libXft.so.2", "libXft.so"], 77,
     pub fn XftCharExists (_2: *mut Display, _1: *mut XftFont, _0: c_uint) -> c_int,
     pub fn XftCharFontSpecRender (_7: *mut Display, _6: c_int, _5: c_ulong, _4: c_ulong, _3: c_int, _2: c_int, _1: *const XftCharFontSpec, _0: c_int) -> (),
     pub fn XftCharIndex (_2: *mut Display, _1: *mut XftFont, _0: c_uint) -> c_uint,

--- a/src/xinerama.rs
+++ b/src/xinerama.rs
@@ -22,7 +22,7 @@ use ::xlib::{
 //
 
 
-x11_link! { Xlib, ["libXinerama.so.1", "libXinerama.so"], 10,
+x11_link! { Xlib, xinerama, ["libXinerama.so.1", "libXinerama.so"], 10,
   pub fn XineramaIsActive (dpy: *mut Display) -> Bool,
   pub fn XineramaQueryExtension (dpy: *mut Display, event_base: c_int, error_base: c_int) -> Bool,
   pub fn XineramaQueryScreens (dpy: *mut Display, number: *mut c_int) -> *mut XineramaScreenInfo,

--- a/src/xinput.rs
+++ b/src/xinput.rs
@@ -25,7 +25,7 @@ use ::xlib::{
 // functions
 //
 
-x11_link! { XInput, ["libXi.so.6", "libXi.so"], 44,
+x11_link! { XInput, xi, ["libXi.so.6", "libXi.so"], 44,
   pub fn XAllowDeviceEvents (_4: *mut Display, _3: *mut XDevice, _2: c_int, _1: c_ulong) -> c_int,
   pub fn XChangeDeviceControl (_4: *mut Display, _3: *mut XDevice, _2: c_int, _1: *mut XDeviceControl) -> c_int,
   pub fn XChangeDeviceDontPropagateList (_5: *mut Display, _4: c_ulong, _3: c_int, _2: *mut c_ulong, _1: c_int) -> c_int,

--- a/src/xinput2.rs
+++ b/src/xinput2.rs
@@ -24,7 +24,7 @@ pub fn XIMaskIsSet(mask: &[::std::os::raw::c_uchar], event: i32) -> bool {
 //
 // functions
 //
-x11_link! { XInput2, ["libXi.so.6", "libXi.so"], 34,
+x11_link! { XInput2, xi, ["libXi.so.6", "libXi.so"], 34,
   pub fn XIAllowEvents (_4: *mut Display, _3: c_int, _2: c_int, _1: c_ulong) -> c_int,
   pub fn XIAllowTouchEvents (_5: *mut Display, _4: c_int, _3: c_uint, _2: c_ulong, _1: c_int) -> c_int,
   pub fn XIBarrierReleasePointer (_4: *mut Display, _3: c_int, _2: c_ulong, _1: c_uint) -> (),

--- a/src/xlib.rs
+++ b/src/xlib.rs
@@ -34,7 +34,7 @@ pub mod xkb {}
 //
 
 
-x11_link! { Xlib, ["libX11.so.6", "libX11.so"], 767,
+x11_link! { Xlib, x11, ["libX11.so.6", "libX11.so"], 767,
   pub fn XActivateScreenSaver (_1: *mut Display) -> c_int,
   pub fn XAddConnectionWatch (_3: *mut Display, _2: Option<unsafe extern "C" fn (*mut Display, *mut c_char, c_int, c_int, *mut *mut c_char)>, _1: *mut c_char) -> c_int,
   pub fn XAddExtension (_1: *mut Display) -> *mut XExtCodes,

--- a/src/xmu.rs
+++ b/src/xmu.rs
@@ -37,7 +37,7 @@ use ::xt::{
 //
 
 
-x11_link! { Xmu, ["libXmu.so.6", "libXmu.so"], 132,
+x11_link! { Xmu, xmu, ["libXmu.so.6", "libXmu.so"], 132,
   pub fn XmuAddCloseDisplayHook (_3: *mut Display, _2: Option<unsafe extern "C" fn (*mut Display, *mut c_char) -> c_int>, _1: *mut c_char) -> *mut c_char,
   pub fn XmuAddInitializer (_2: Option<unsafe extern "C" fn (XtAppContext, *mut c_char)>, _1: *mut c_char) -> (),
   pub fn XmuAllStandardColormaps (_1: *mut Display) -> c_int,

--- a/src/xrandr.rs
+++ b/src/xrandr.rs
@@ -15,7 +15,7 @@ use xrender::{ XFixed, XTransform };
 //
 
 
-x11_link! { Xrandr, ["libXrandr.so.2", "libXrandr.so"], 70,
+x11_link! { Xrandr, xrandr, ["libXrandr.so.2", "libXrandr.so"], 70,
     pub fn XRRAddOutputMode (dpy: *mut Display, output: RROutput, mode: RRMode) -> (),
     pub fn XRRAllocGamma (size: c_int) -> *mut XRRCrtcGamma,
     pub fn XRRAllocModeInfo (name: *const c_char, nameLength: c_int) -> *mut XRRModeInfo,

--- a/src/xrecord.rs
+++ b/src/xrecord.rs
@@ -23,7 +23,7 @@ use ::xlib::{
 //
 
 
-x11_link! { Xf86vmode, ["libXtst.so.6", "libXtst.so"], 14,
+x11_link! { Xf86vmode, xtst, ["libXtst.so.6", "libXtst.so"], 14,
   pub fn XRecordAllocRange () -> *mut XRecordRange,
   pub fn XRecordCreateContext (_6: *mut Display, _5: c_int, _4: *mut c_ulong, _3: c_int, _2: *mut *mut XRecordRange, _1: c_int) -> c_ulong,
   pub fn XRecordDisableContext (_2: *mut Display, _1: c_ulong) -> c_int,

--- a/src/xrender.rs
+++ b/src/xrender.rs
@@ -31,7 +31,7 @@ use ::xlib::{
 //
 
 
-x11_link! { Xrender, ["libXrender.so.1", "libXrender.so"], 44,
+x11_link! { Xrender, xrender, ["libXrender.so.1", "libXrender.so"], 44,
   pub fn XRenderAddGlyphs (_7: *mut Display, _6: c_ulong, _5: *const c_ulong, _4: *const XGlyphInfo, _3: c_int, _2: *const c_char, _1: c_int) -> (),
   pub fn XRenderAddTraps (_6: *mut Display, _5: c_ulong, _4: c_int, _3: c_int, _2: *const XTrap, _1: c_int) -> (),
   pub fn XRenderChangePicture (_4: *mut Display, _3: c_ulong, _2: c_ulong, _1: *const XRenderPictureAttributes) -> (),

--- a/src/xss.rs
+++ b/src/xss.rs
@@ -14,7 +14,7 @@ use xlib::{ Atom, Bool, Display, Drawable, Status, Time, Visual, XEvent, XID, XS
 //
 
 
-x11_link! { Xss, ["libXss.so.2", "libXss.so"], 11,
+x11_link! { Xss, xscrnsaver, ["libXss.so.2", "libXss.so"], 11,
   pub fn XScreenSaverQueryExtension (_1: *mut Display, _2: *mut c_int, _3: *mut c_int) -> Bool,
   pub fn XScreenSaverQueryVersion (_1: *mut Display, _2: *mut c_int, _3: *mut c_int) -> Status,
   pub fn XScreenSaverAllocInfo () -> *mut XScreenSaverInfo,

--- a/src/xt.rs
+++ b/src/xt.rs
@@ -35,7 +35,7 @@ use ::xlib::{
 //
 
 
-x11_link! { Xt, ["libXt.so.6", "libXt.so"], 300,
+x11_link! { Xt, xt, ["libXt.so.6", "libXt.so"], 300,
   pub fn XtAddActions (_2: *mut XtActionsRec, _1: c_uint) -> (),
   pub fn XtAddCallback (_4: Widget, _3: *const c_char, _2: Option<unsafe extern "C" fn (Widget, *mut c_void, *mut c_void)>, _1: *mut c_void) -> (),
   pub fn XtAddCallbacks (_3: Widget, _2: *const c_char, _1: XtCallbackList) -> (),

--- a/src/xtest.rs
+++ b/src/xtest.rs
@@ -21,7 +21,7 @@ use ::xlib::{
 //
 
 
-x11_link! { Xf86vmode, ["libXtst.so.6", "libXtst.so"], 15,
+x11_link! { Xf86vmode, xtst, ["libXtst.so.6", "libXtst.so"], 15,
   pub fn XTestCompareCurrentCursorWithWindow (_2: *mut Display, _1: c_ulong) -> c_int,
   pub fn XTestCompareCursorWithWindow (_3: *mut Display, _2: c_ulong, _1: c_ulong) -> c_int,
   pub fn XTestDiscard (_1: *mut Display) -> c_int,

--- a/x11-dl/Cargo.toml
+++ b/x11-dl/Cargo.toml
@@ -10,3 +10,6 @@ build = "build.rs"
 [dependencies]
 lazy_static = "0.2.0"
 libc = "0.2"
+
+[build-dependencies]
+pkg-config = "0.3.8"

--- a/x11-dl/build.rs
+++ b/x11-dl/build.rs
@@ -2,6 +2,42 @@
 // The X11 libraries are available under the MIT license.
 // These bindings are public domain.
 
-fn main () {
+extern crate pkg_config;
+
+use std::env;
+use std::fs::File;
+use std::io::Write;
+use std::path::Path;
+
+fn main() {
+    let libraries = ["xext",
+                     "gl",
+                     "xcursor",
+                     "xxf86vm",
+                     "xft",
+                     "xinerama",
+                     "xi",
+                     "x11",
+                     "xmu",
+                     "xrandr",
+                     "xtst",
+                     "xrender",
+                     "xscrnsaver",
+                     "xt"];
+
+    let mut config = String::new();
+    for lib in libraries.iter() {
+        let libdir = match pkg_config::get_variable(lib, "libdir") {
+            Ok(libdir) => format!("Some(\"{}\")", libdir),
+            Err(_) => "None".to_string(),
+        };
+        config.push_str(&format!("pub const {}: Option<&'static str> = {};\n", lib, libdir));
+    }
+    let config = format!("pub mod config {{ pub mod libdir {{\n{}}}\n}}", config);
+    let out_dir = env::var("OUT_DIR").unwrap();
+    let dest_path = Path::new(&out_dir).join("config.rs");
+    let mut f = File::create(&dest_path).unwrap();
+    f.write_all(&config.into_bytes()).unwrap();
+
     println!("cargo:rustc-link-lib=dl");
 }

--- a/x11-dl/src/old_xrandr.rs
+++ b/x11-dl/src/old_xrandr.rs
@@ -2,7 +2,7 @@
 // The X11 libraries are available under the MIT license.
 // These bindings are public domain.
 
-x11_link! { Xrandr_2_2_0, ["libXrandr.so.2.2.0", "libXrandr.so.2", "libXrandr.so"], 65,
+x11_link! { Xrandr_2_2_0, xrandr, ["libXrandr.so.2.2.0", "libXrandr.so.2", "libXrandr.so"], 65,
     pub fn XRRAddOutputMode (dpy: *mut Display, output: RROutput, mode: RRMode) -> (),
     pub fn XRRAllocGamma (size: c_int) -> *mut XRRCrtcGamma,
     pub fn XRRAllocModeInfo (name: *const c_char, nameLength: c_int) -> *mut XRRModeInfo,

--- a/x11/src/link.rs
+++ b/x11/src/link.rs
@@ -3,7 +3,7 @@
 // These bindings are public domain.
 
 macro_rules! x11_link {
-  { $struct_name:ident, [$($lib_name:expr),*], $nsyms:expr,
+  { $struct_name:ident, $pkg_name:expr, [$($lib_name:expr),*], $nsyms:expr,
     $(pub fn $fn_name:ident ($($param_name:ident : $param_type:ty),*) -> $ret_type:ty,)*
     variadic:
     $(pub fn $vfn_name:ident ($($vparam_name: ident : $vparam_type:ty),+) -> $vret_type:ty,)*


### PR DESCRIPTION
Some source-based distributions do not have libraries in the standard
paths such as /usr/lib or /lib and don't make all libraries available
though LD_LIBRARY_PATH either (an example is NixOS). Before this patch,
x11-dl would not work on these kind of distributions. To fix this,
x11-dl now searches the path of the X11 libraries determined at compile
time as a last fallback.

This change is backwards compatible, as it still searches the old
locations first and only falls back to the compile-time location if no
library was found in the default locations. Also, if the library is not
available at build time, no fallback will be used, so x11-dl still
compiles without having all those libraries available at build-time.