### PR TITLE
x11-dl: export xss module

### DIFF
--- a/x11-dl/src/lib.rs
+++ b/x11-dl/src/lib.rs
@@ -34,6 +34,7 @@ pub mod xmd;
 pub mod xmu;
 pub mod xrecord;
 pub mod xrender;
+pub mod xss;
 pub mod xt;
 pub mod xtest;
 


### PR DESCRIPTION
x11 already exports this module

(I found that this module was not exported because of a warning 
generated with the new pkgconfig changes)