### PR TITLE
Fix linking on BSD systems

### DIFF
--- a/x11-dl/build.rs
+++ b/x11-dl/build.rs
@@ -40,5 +40,10 @@ fn main() {
     let mut f = File::create(&dest_path).unwrap();
     f.write_all(&config.into_bytes()).unwrap();
 
-    println!("cargo:rustc-link-lib=dl");
+    let target = env::var("TARGET").unwrap();
+    if target.contains("linux") {
+        println!("cargo:rustc-link-lib=dl");
+    } else if target.contains("freebsd") || target.contains("dragonfly") {
+        println!("cargo:rustc-link-lib=c");
+    }
 }


### PR DESCRIPTION
After this change, x11-dl builds on FreeBSD.
 
Thanks to [libloading's build.rs](https://github.com/nagisa/rust_libloading/blob/master/build.rs) for info about other BSDs.