### PR TITLE
Use metadeps to specify pkg-config dependencies declaratively

### DIFF
--- a/x11/Cargo.toml
+++ b/x11/Cargo.toml
@@ -19,14 +19,32 @@ xlib = []
 xlib_xcb = []
 xmu = []
 xrandr = []
-xrecord = []
+xrecord = ["xtst"]
 xrender = []
 xss = []
 xt = []
-xtest = []
+xtest = ["xtst"]
+xtst = []
 
 [dependencies]
 libc = "0.2"
 
 [build-dependencies]
-pkg-config = "0.3.5"
+metadeps = "1.1"
+
+[package.metadata.pkg-config]
+gl = { version = "1", feature = "glx" }
+x11 = { version = "1.6", feature = "xlib" }
+x11-xcb = { version = "1.6", feature = "xlib_xcb" }
+xcursor = { version = "1.1", feature = "xcursor" }
+xext = { version = "1.3", feature = "dpms" }
+xft = { version = "2.1", feature = "xft" }
+xi = { version = "1.7", feature = "xinput" }
+xinerama = { version = "1.1", feature = "xinerama" }
+xmu = { version = "1.1", feature = "xmu" }
+xrandr = { version = "1.5", feature = "xrandr" }
+xrender = { version = "0.9.6", feature = "xrender" }
+xscrnsaver = { version = "1.2", feature = "xss" }
+xt = { version = "1.1", feature = "xt" }
+xtst = { version = "1.2", feature = "xtst" }
+xxf86vm = { version = "1.1", feature = "xf86vmode" }

--- a/x11/build.rs
+++ b/x11/build.rs
@@ -2,23 +2,8 @@
 // The X11 libraries are available under the MIT license.
 // These bindings are public domain.
 
-extern crate pkg_config;
+extern crate metadeps;
 
 fn main () {
-  if cfg!(feature="dpms") { pkg_config::find_library("xext").unwrap(); }
-  if cfg!(feature="glx") { pkg_config::find_library("gl").unwrap(); }
-  if cfg!(feature="xcursor") { pkg_config::find_library("xcursor").unwrap(); }
-  if cfg!(feature="xf86vmode") { pkg_config::find_library("xxf86vm").unwrap(); }
-  if cfg!(feature="xft") { pkg_config::find_library("xft").unwrap(); }
-  if cfg!(feature="xinerama") { pkg_config::find_library("xinerama").unwrap(); }
-  if cfg!(feature="xinput") { pkg_config::find_library("xi").unwrap(); }
-  if cfg!(feature="xlib") { pkg_config::find_library("x11").unwrap(); }
-  if cfg!(feature="xlib_xcb") { pkg_config::find_library("x11-xcb").unwrap(); }
-  if cfg!(feature="xmu") { pkg_config::find_library("xmu").unwrap(); }
-  if cfg!(feature="xrandr") { pkg_config::find_library("xrandr").unwrap(); }
-  if cfg!(feature="xrecord") { pkg_config::find_library("xtst").unwrap(); }
-  if cfg!(feature="xrender") { pkg_config::find_library("xrender").unwrap(); }
-  if cfg!(feature="xss") { pkg_config::find_library("xscrnsaver").unwrap(); }
-  if cfg!(feature="xt") { pkg_config::find_library("xt").unwrap(); }
-  if cfg!(feature="xtest") { pkg_config::find_library("xtst").unwrap(); }
+  metadeps::probe().unwrap();
 }


### PR DESCRIPTION
This makes it easier for distribution packaging tools to generate
appropriate package dependencies.