### PR TITLE
Add bindings for XICCEncodingStyle, copied from /usr/include/X11/Xutil.h

### DIFF
--- a/src/xlib.rs
+++ b/src/xlib.rs
@@ -3231,3 +3231,10 @@ pub const IconMaskHint: c_long = 1 << 5;
 pub const WindowGroupHint: c_long = 1 << 6;
 pub const AllHints: c_long = InputHint | StateHint | IconPixmapHint | IconWindowHint | IconPositionHint | IconMaskHint | WindowGroupHint;
 pub const XUrgencyHint: c_long = 1 << 8;
+
+// XICCEncodingStyle
+pub const XStringStyle: c_int = 0;
+pub const XCompoundTextStyle: c_int = 1;
+pub const XTextStyle: c_int = 2;
+pub const XStdICCTextStyle: c_int = 3;
+pub const XUTF8StringStyle: c_int = 4;


### PR DESCRIPTION
Edit:

I tried defining a rust enum for this but there's already a XICCEncodingStyle: c_int decl for this in xlib.rs which I didn't notice before sending the PR.

I've changed this to just exporting the XICCEncodingStyle variants as constants.

Thanks!