### PR TITLE
XineramaQueryExtension arguments are pointers not by-val

### DIFF
--- a/src/xinerama.rs
+++ b/src/xinerama.rs
@@ -24,7 +24,7 @@ use ::xlib::{
 
 x11_link! { Xlib, xinerama, ["libXinerama.so.1", "libXinerama.so"], 10,
   pub fn XineramaIsActive (dpy: *mut Display) -> Bool,
-  pub fn XineramaQueryExtension (dpy: *mut Display, event_base: c_int, error_base: c_int) -> Bool,
+  pub fn XineramaQueryExtension (dpy: *mut Display, event_base: *mut c_int, error_base: *mut c_int) -> Bool,
   pub fn XineramaQueryScreens (dpy: *mut Display, number: *mut c_int) -> *mut XineramaScreenInfo,
   pub fn XineramaQueryVersion (dpy: *mut Display, major_versionp: *mut c_int, minor_versionp: *mut c_int) -> Status,
   pub fn XPanoramiXAllocInfo () -> *mut XPanoramiXInfo,


### PR DESCRIPTION
See the docs here: https://linux.die.net/man/3/xineramaqueryextension

> Bool XineramaQueryExtension (Display *dpy, int *event_base_return, int *error_base_return);

I'm a bit new to rust, the ability for this error to exist surprised me a little.  This got me wondering, does rust have the ability to check compatibility with C header files?  Guessing not, and FFI is relying on manual curation or autogeneration?