### PR TITLE
Recommend xcb, add readme to crates

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,5 +9,14 @@
 The X11 libraries written in C are available under the terms of the MIT license.
 These bindings are available as public domain.
 
+Note that it in most cases it makes sense to instead use the XCB library, via
+the [xcb](https://crates.io/crates/xcb) crate. XCB is a newer library for X11,
+which supports multithreaded access and saner error handling, among other
+improvements. Using xlib may still make sense for the following reasons:
+
+* More examples / documentation of usage.
+* When porting existing code which uses xlib.
+* When requiring features only supported by xlib.
+
 As of 2017 I don't have as much time to work on this myself as I once did (due to school and work,
 both full time), but feel free to submit a pull request if anything you need is missing!

--- a/x11-dl/Cargo.toml
+++ b/x11-dl/Cargo.toml
@@ -8,6 +8,7 @@ repository = "https://github.com/Daggerbot/x11-rs.git"
 build = "build.rs"
 documentation = "https://docs.rs/x11-dl"
 workspace = ".."
+readme = "../README.md"
 
 [dependencies]
 lazy_static = "0.2.0"

--- a/x11/Cargo.toml
+++ b/x11/Cargo.toml
@@ -8,6 +8,7 @@ repository = "https://github.com/Daggerbot/x11-rs.git"
 build = "build.rs"
 documentation = "https://docs.rs/x11"
 workspace = ".."
+readme = "../README.md"
 
 [features]
 dpms = []


### PR DESCRIPTION
I went down the path of using the x11 crate without realizing the choice I was making between it and xcb.  Happily, haven't implemented all that much that uses xlib.

Anyway, figured it'd be good to have the readme info on the crates, and point out the xcb alternative.

Also, what is the difference between `x11` and `x11-dl`?