### PR TITLE
Add dox feature to suppress probing native packages

### DIFF
--- a/x11/Cargo.toml
+++ b/x11/Cargo.toml
@@ -27,6 +27,7 @@ xss = []
 xt = []
 xtest = ["xtst"]
 xtst = []
+dox = []
 
 [dependencies]
 libc = "0.2"

--- a/x11/build.rs
+++ b/x11/build.rs
@@ -5,5 +5,6 @@
 extern crate metadeps;
 
 fn main () {
+  if cfg!(feature = "dox") { return; }
   metadeps::probe().unwrap();
 }


### PR DESCRIPTION
Helps build build docs for all platform for https://crates.io/crates/cairo and https://crates.io/crates/cairo-sys.

Part of https://github.com/gtk-rs/gir/pull/467
Inspired by https://github.com/rust-lang/rust/pull/43348

In https://github.com/gtk-rs/ we try document all functions with configs like [`#[cfg(any(target_os = "macos", target_os = "ios", feature = "dox"))]`](https://github.com/gtk-rs/cairo/blob/master/src/surface.rs#L69) or https://github.com/gtk-rs/cairo/blob/master/cairo-sys-rs/src/lib.rs#L541-L547

